### PR TITLE
0.7.1

### DIFF
--- a/BuildMasterAutomation/BuildMasterAutomation.psd1
+++ b/BuildMasterAutomation/BuildMasterAutomation.psd1
@@ -12,7 +12,7 @@
     RootModule = 'BuildMasterAutomation.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.7.0'
+    ModuleVersion = '0.7.1'
 
     # ID used to uniquely identify this module
     GUID = 'cc5a1865-e5f8-45f2-b0d3-317a1611a965'
@@ -144,10 +144,7 @@ The BuildMasterAutomation module is a PowerShell module for working with BuildMa
 
             # ReleaseNotes of this module
             ReleaseNotes = @'
-* Created Get-BMServerRole, New-BMServerRole, and Remove-BMServerRole functions for managing server roles.
-* Created Get-BMServer, New-BMServer, and Remove-BMServer functions for managing servers.
-* Created Get-BMEnvironment, New-BMEnvironment, Disable-BMEnvironment, and Enable-BMEnvironment functions for managing environments.
-* Created Get-BMVariable, Remove-BMVariable, and Set-BMVariable functions for managing variables.
+* Fixed: Get-BMApplication, Get-BMApplicationGroup, and Get-BMPipeline fail if the user's WhatIfPreference is true.
 '@
         } # End of PSData hashtable
 

--- a/BuildMasterAutomation/BuildMasterAutomation.psd1
+++ b/BuildMasterAutomation/BuildMasterAutomation.psd1
@@ -145,6 +145,8 @@ The BuildMasterAutomation module is a PowerShell module for working with BuildMa
             # ReleaseNotes of this module
             ReleaseNotes = @'
 * Fixed: Get-BMApplication, Get-BMApplicationGroup, and Get-BMPipeline fail if the user's WhatIfPreference is true.
+* Fixed: New-BMEnvironment wasn't setting an environment's parent.
+* Fixed: Get-BMEnvironment wasn't returning an environments parent.
 '@
         } # End of PSData hashtable
 

--- a/BuildMasterAutomation/Functions/Get-BMApplication.ps1
+++ b/BuildMasterAutomation/Functions/Get-BMApplication.ps1
@@ -45,6 +45,8 @@ function Get-BMApplication
 
     Set-StrictMode -Version 'Latest'
     Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+    # Invoke-BMNativeApiMethod uses POST, but we're reading data, so always make the request.
+    $WhatIfPreference = $false
 
     $parameters = @{
                         Application_Count = 0;

--- a/BuildMasterAutomation/Functions/Get-BMApplicationGroup.ps1
+++ b/BuildMasterAutomation/Functions/Get-BMApplicationGroup.ps1
@@ -34,6 +34,7 @@ function Get-BMApplicationGroup
     
     Set-StrictMode -Version 'Latest'
     Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+    $WhatIfPreference = $false
     
     $parameters = @{}
     

--- a/BuildMasterAutomation/Functions/Get-BMEnvironment.ps1
+++ b/BuildMasterAutomation/Functions/Get-BMEnvironment.ps1
@@ -66,7 +66,8 @@ function Get-BMEnvironment
             [pscustomobject]@{
                                 id = $_.Environment_Id;
                                 name = $_.Environment_Name;
-                                active = $_.Active_Indicator
+                                active = $_.Active_Indicator;
+                                parentName = $_.Parent_Environment_Name;
                             }
         } |
         Where-Object {

--- a/BuildMasterAutomation/Functions/Get-BMPipeline.ps1
+++ b/BuildMasterAutomation/Functions/Get-BMPipeline.ps1
@@ -65,6 +65,7 @@ function Get-BMPipeline
 
     Set-StrictMode -Version 'Latest'
     Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+    $WhatIfPreference = $false
 
     $parameter = @{ }
     $methodName = 'Pipelines_GetPipelines'

--- a/BuildMasterAutomation/Functions/New-BMEnvironment.ps1
+++ b/BuildMasterAutomation/Functions/New-BMEnvironment.ps1
@@ -42,7 +42,7 @@ function New-BMEnvironment
 
     $parameter = @{
                     name = $Name;
-                    parent = $ParentName;
+                    parentName = $ParentName;
                  }
     $encodedName = [uri]::EscapeDataString($Name)
     Invoke-BMRestMethod -Session $Session -Name ('infrastructure/environments/create/{0}' -f $encodedName) -Method Post -Parameter $parameter -AsJson

--- a/Tests/Get-BMApplication.Tests.ps1
+++ b/Tests/Get-BMApplication.Tests.ps1
@@ -55,11 +55,31 @@ function ThenReturnsAllApplications
 function WhenGettingAllApplications
 {
     param(
-        [Switch]
-        $Force
+        [Switch]$Force,
+
+        [Switch]$WhatIf
     )
 
-    $script:result = Get-BMApplication -Session $BMTestSession @PSBoundParameters
+    $originalWhatIf = $WhatIfPreference
+    if( $WhatIf )
+    {
+        $WhatIfPreference = $true
+    }
+
+    $optionalParams = @{ }
+    if( $Force )
+    {
+        $optionalParams['Force'] = $true
+    }
+
+    try
+    {
+        $script:result = Get-BMApplication -Session $BMTestSession @optionalParams
+    }
+    finally
+    {
+        $WhatIfPreference = $originalWhatIf
+    }
 }
 
 function WhenGettingAnApplication
@@ -107,3 +127,11 @@ Describe 'Get-BMApplication.when getting a specific disabled applicationn' {
     }
 }
 
+Describe 'Get-BMApplication.when user''s WhatIfPreference is true' {
+    It 'should return applications' {
+        $app1 = GivenAnApplication -Name $PSCommandPath
+        $app2 = GivenAnApplication -Name $PSCommandPath
+        WhenGettingAllApplications -WhatIf
+        ThenReturnsAllApplications $app1,$app2
+    }
+}

--- a/Tests/Get-BMApplication.Tests.ps1
+++ b/Tests/Get-BMApplication.Tests.ps1
@@ -13,11 +13,9 @@ function ThenReturns
         $Application
     )
 
-    It ('should return {0} applications' -f $Description) {
-        foreach( $app in $Application )
-        {
-            $result | Where-Object { $_.Application_Id -eq $app.Application_Id } | Should -Not -BeNullOrEmpty
-        }
+    foreach( $app in $Application )
+    {
+        $result | Where-Object { $_.Application_Id -eq $app.Application_Id } | Should -Not -BeNullOrEmpty
     }
 }
 
@@ -28,11 +26,9 @@ function ThenDoesNotReturnInactiveApplications
         $Application
     )
 
-    It ('should not return inactive applications') {
-        foreach( $app in $Application )
-        {
-            $result | Where-Object { $_.Application_Id -eq $app.Application_Id } | Should -BeNullOrEmpty
-        }
+    foreach( $app in $Application )
+    {
+        $result | Where-Object { $_.Application_Id -eq $app.Application_Id } | Should -BeNullOrEmpty
     }
 }
 
@@ -76,31 +72,38 @@ function WhenGettingAnApplication
 }
 
 Describe 'Get-BMApplication.when getting all applications' {
-    $app1 = GivenAnApplication -Name $PSCommandPath
-    $app2 = GivenAnApplication -Name $PSCommandPath
-    $app3 = GivenAnApplication -Name $PSCommandPath -ThatIsDisabled
+    It 'should get active applications' {
+        $app1 = GivenAnApplication -Name $PSCommandPath
+        $app2 = GivenAnApplication -Name $PSCommandPath
+        $app3 = GivenAnApplication -Name $PSCommandPath -ThatIsDisabled
 
-    WhenGettingAllApplications
+        WhenGettingAllApplications
 
-    ThenReturnsActiveApplications $app1,$app2
-    ThenDoesNotReturnInactiveApplications $app3
+        ThenReturnsActiveApplications $app1,$app2
+        ThenDoesNotReturnInactiveApplications $app3
+    }
 }
 
 Describe 'Get-BMApplication.when getting all applications including inactive application' {
-    $app1 = GivenAnApplication -Name $PSCommandPath
-    $app2 = GivenAnApplication -Name $PSCommandPath
-    $app3 = GivenAnApplication -Name $PSCommandPath -ThatIsDisabled
+    It 'should return active and inactive applications' {
+        $app1 = GivenAnApplication -Name $PSCommandPath
+        $app2 = GivenAnApplication -Name $PSCommandPath
+        $app3 = GivenAnApplication -Name $PSCommandPath -ThatIsDisabled
 
-    WhenGettingAllApplications -Force
+        WhenGettingAllApplications -Force
 
-    ThenReturnsAllApplications $app1,$app2,$app3
+        ThenReturnsAllApplications $app1,$app2,$app3
+    }
 }
 
 
 Describe 'Get-BMApplication.when getting a specific disabled applicationn' {
-    $app = GivenAnApplication -Name $PSCommandPath -ThatIsDisabled
+    It 'should get disabled application' {
+        $app = GivenAnApplication -Name $PSCommandPath -ThatIsDisabled
 
-    WhenGettingAnApplication $app.Application_Name
+        WhenGettingAnApplication $app.Application_Name
 
-    ThenReturns -Description '' -Application $app
+        ThenReturns -Description '' -Application $app
+    }
 }
+

--- a/Tests/Get-BMApplicationGroup.Tests.ps1
+++ b/Tests/Get-BMApplicationGroup.Tests.ps1
@@ -33,13 +33,28 @@ function GivenApplicationGroup
 function WhenGettingApplicationGroup
 {
     param(
-        [String]
-        $Name
+        [String]$Name,
+        
+        [Switch]$WhatIf
     )
 
     $Global:Error.Clear()
 
-    $script:getAppGroups = Get-BMApplicationGroup -Session $conn $Name
+    $optionalParams = @{ }
+
+    $originalWhatIf = $Global:WhatIfPreference
+    if( $WhatIf )
+    {
+        $Global:WhatIfPreference = $true
+    }
+    try
+    {
+        $script:getAppGroups = Get-BMApplicationGroup -Session $conn $Name
+    }
+    finally
+    {
+        $Global:WhatIfPreference = $originalWhatIf
+    }
 }
 
 function ThenShouldNotThrowErrors
@@ -118,5 +133,15 @@ Describe 'Get-BMApplicationGroup.when no application groups exist' {
         WhenGettingApplicationGroup
         ThenShouldNotThrowErrors
         ThenShouldNotReturnApplicationGroup
+    }
+}
+
+Describe 'Get-BMApplicationGroup.when WhatIfPreference is true' {
+    It 'should return application group' {
+        Init
+        GivenApplicationGroup 'One'
+        WhenGettingApplicationGroup 'One' -WhatIf
+        ThenShouldNotThrowErrors
+        ThenShouldReturnApplicationGroup 'One'
     }
 }

--- a/Tests/Get-BMApplicationGroup.Tests.ps1
+++ b/Tests/Get-BMApplicationGroup.Tests.ps1
@@ -47,9 +47,7 @@ function ThenShouldNotThrowErrors
     param(
     )
 
-    It 'should not throw any errors' {
-        $Global:Error | Should BeNullOrEmpty
-    }
+    $Global:Error | Should BeNullOrEmpty
 }
 
 function ThenShouldReturnApplicationGroup
@@ -59,14 +57,10 @@ function ThenShouldReturnApplicationGroup
         $GroupName
     )
     
-    It ('should return exactly {0} application groups.' -f @( $GroupName ).Count) {
-        @( $script:getAppGroups ).Count | Should Be @( $GroupName ).Count
-    }
+    $script:getAppGroups | Should -HaveCount @( $GroupName ).Count
     
     $GroupName | ForEach-Object {
-        It ('should return the application group: {0}.' -f $_) {
-            $script:getAppGroups.ApplicationGroup_Name -contains $_ | Should Be $true
-        }
+        $script:getAppGroups.ApplicationGroup_Name -contains $_ | Should -BeTrue
     }
 }
 
@@ -75,46 +69,54 @@ function ThenShouldNotReturnApplicationGroup
     param(
     )
     
-    It 'should not return any application groups' {
-        $script:getAppGroups | Should BeNullOrEmpty
-    }
+    $script:getAppGroups | Should -BeNullOrEmpty
 }
 
 Describe 'Get-BMApplicationGroup.when getting all application groups' {
-    Init
-    GivenApplicationGroup 'BMApplicationGroup1', 'BMApplicationGroup2', 'BMApplicationGroup3'
-    WhenGettingApplicationGroup
-    ThenShouldNotThrowErrors
-    ThenShouldReturnApplicationGroup 'BMApplicationGroup1', 'BMApplicationGroup2', 'BMApplicationGroup3'
+    It 'should get application groups' {
+        Init
+        GivenApplicationGroup 'BMApplicationGroup1', 'BMApplicationGroup2', 'BMApplicationGroup3'
+        WhenGettingApplicationGroup
+        ThenShouldNotThrowErrors
+        ThenShouldReturnApplicationGroup 'BMApplicationGroup1', 'BMApplicationGroup2', 'BMApplicationGroup3'
+    }
 }
 
 Describe 'Get-BMApplicationGroup.when getting a specific application group' {
-    Init
-    GivenApplicationGroup 'BMApplicationGroup1', 'BMApplicationGroup2', 'BMApplicationGroup3'
-    WhenGettingApplicationGroup 'BMApplicationGroup2'
-    ThenShouldNotThrowErrors
-    ThenShouldReturnApplicationGroup 'BMApplicationGroup2'
+    It 'should get that application group' {
+        Init
+        GivenApplicationGroup 'BMApplicationGroup1', 'BMApplicationGroup2', 'BMApplicationGroup3'
+        WhenGettingApplicationGroup 'BMApplicationGroup2'
+        ThenShouldNotThrowErrors
+        ThenShouldReturnApplicationGroup 'BMApplicationGroup2'
+    }
 }
 
 Describe 'Get-BMApplicationGroup.when for application group by wildcard' {
-    Init
-    GivenApplicationGroup 'BMApplicationGroup1', 'BMApplicationGroup2', 'BuildMasterAppGroup3'
-    WhenGettingApplicationGroup 'BMApplication*'
-    ThenShouldNotThrowErrors
-    ThenShouldReturnApplicationGroup 'BMApplicationGroup1', 'BMApplicationGroup2'
+    It 'should get find the application groups' {
+        Init
+        GivenApplicationGroup 'BMApplicationGroup1', 'BMApplicationGroup2', 'BuildMasterAppGroup3'
+        WhenGettingApplicationGroup 'BMApplication*'
+        ThenShouldNotThrowErrors
+        ThenShouldReturnApplicationGroup 'BMApplicationGroup1', 'BMApplicationGroup2'
+    }
 }
 
 Describe 'Get-BMApplicationGroup.when searching for application group that doesn''t exist' {
-    Init
-    GivenApplicationGroup 'BMApplicationGroup1', 'BMApplicationGroup2', 'BMApplicationGroup3'
-    WhenGettingApplicationGroup 'NonExistentApplicationGroup2'
-    ThenShouldNotThrowErrors
-    ThenShouldNotReturnApplicationGroup
+    It 'should return nothing' {
+        Init
+        GivenApplicationGroup 'BMApplicationGroup1', 'BMApplicationGroup2', 'BMApplicationGroup3'
+        WhenGettingApplicationGroup 'NonExistentApplicationGroup2'
+        ThenShouldNotThrowErrors
+        ThenShouldNotReturnApplicationGroup
+    }
 }
 
 Describe 'Get-BMApplicationGroup.when no application groups exist' {
-    Init
-    WhenGettingApplicationGroup
-    ThenShouldNotThrowErrors
-    ThenShouldNotReturnApplicationGroup
+    It 'should return nothing' {
+        Init
+        WhenGettingApplicationGroup
+        ThenShouldNotThrowErrors
+        ThenShouldNotReturnApplicationGroup
+    }
 }

--- a/Tests/Get-BMPipeline.Tests.ps1
+++ b/Tests/Get-BMPipeline.Tests.ps1
@@ -44,12 +44,10 @@ function ThenReturned
         $Name
     )
 
-    It ('should return pipelines') {
-        ($result | Measure-Object).Count | Should -Be ($Name | Measure-Object).Count
-        foreach( $nameItem in $Name )
-        {
-            $result | Where-Object { $_.Pipeline_Name -eq $nameItem } | Should -Not -BeNullOrEmpty
-        }
+    ($result | Measure-Object).Count | Should -Be ($Name | Measure-Object).Count
+    foreach( $nameItem in $Name )
+    {
+        $result | Where-Object { $_.Pipeline_Name -eq $nameItem } | Should -Not -BeNullOrEmpty
     }
 }
 
@@ -81,44 +79,54 @@ function WhenGettingPipeline
 }
 
 Describe 'Get-BMPipeline.when requesting all pipelines' {
-    Init
-    GivenPipeline 'One'
-    GivenPipeline 'Two'
-    WhenGettingPipeline
-    ThenReturned 'One','Two'
+    It 'should return all pipelines' {
+        Init
+        GivenPipeline 'One'
+        GivenPipeline 'Two'
+        WhenGettingPipeline
+        ThenReturned 'One','Two'
+    }
 }
 
 Describe 'Get-BMPipeline.when requesting a pipeline by name' {
-    Init
-    GivenPipeline 'One'
-    GivenPipeline 'Two'
-    WhenGettingPipeline 'One'
-    ThenReturned 'One'
+    It 'should return only that pipeline' {
+        Init
+        GivenPipeline 'One'
+        GivenPipeline 'Two'
+        WhenGettingPipeline 'One'
+        ThenReturned 'One'
+    }
 }
 
 Describe 'Get-BMPipeline.when requesting a pipelines using a wildcard' {
-    Init
-    GivenPipeline 'OneA'
-    GivenPipeline 'OneB'
-    GivenPipeline 'Two'
-    WhenGettingPipeline 'One*'
-    ThenReturned 'OneA','OneB'
+    It 'should return pipelines that match' {
+        Init
+        GivenPipeline 'OneA'
+        GivenPipeline 'OneB'
+        GivenPipeline 'Two'
+        WhenGettingPipeline 'One*'
+        ThenReturned 'OneA','OneB'
+    }
 }
 
 Describe 'Get-BMPipeline.when requesting an application''s pipelines' {
-    Init
-    $app = GivenApplication 'One'
-    GivenPipeline 'One_1' -ForApplication $app.Application_Id
-    GivenPipeline 'One_2' -ForApplication $app.Application_Id
-    GivenPipeline 'Two'
-    WhenGettingPipeline -ForApplication $app.Application_Id
-    ThenReturned 'One_1','One_2'
+    It 'should return those pipelines' {
+        Init
+        $app = GivenApplication 'One'
+        GivenPipeline 'One_1' -ForApplication $app.Application_Id
+        GivenPipeline 'One_2' -ForApplication $app.Application_Id
+        GivenPipeline 'Two'
+        WhenGettingPipeline -ForApplication $app.Application_Id
+        ThenReturned 'One_1','One_2'
+    }
 }
 
 Describe 'Get-BMPipeline.when requesting a pipeline by ID' {
-    Init
-    $p = GivenPipeline 'One'
-    GivenPipeline 'Two'
-    WhenGettingPipeline -ForPipeline $p.Pipeline_Id
-    ThenReturned 'One'
+    It 'should that pipeline' {
+        Init
+        $p = GivenPipeline 'One'
+        GivenPipeline 'Two'
+        WhenGettingPipeline -ForPipeline $p.Pipeline_Id
+        ThenReturned 'One'
+    }
 }

--- a/Tests/Get-BMPipeline.Tests.ps1
+++ b/Tests/Get-BMPipeline.Tests.ps1
@@ -56,7 +56,8 @@ function WhenGettingPipeline
     param(
         $Name,
         $ForApplication,
-        $ForPipeline
+        $ForPipeline,
+        [Switch]$WhatIf
     )
 
     $optionalParams = @{ }
@@ -75,7 +76,20 @@ function WhenGettingPipeline
         $optionalParams['ID'] = $ForPipeline
     }
 
-    $script:result = Get-BMPipeline -Session $session @optionalParams
+    $originalWhatIf = $WhatIfPreference
+    try
+    {
+        if( $WhatIf )
+        {
+            $Global:WhatIfPreference = $true
+        }
+
+        $script:result = Get-BMPipeline -Session $session @optionalParams
+    }
+    finally
+    {
+        $Global:WhatIfPreference = $originalWhatIf
+    }
 }
 
 Describe 'Get-BMPipeline.when requesting all pipelines' {
@@ -127,6 +141,15 @@ Describe 'Get-BMPipeline.when requesting a pipeline by ID' {
         $p = GivenPipeline 'One'
         GivenPipeline 'Two'
         WhenGettingPipeline -ForPipeline $p.Pipeline_Id
+        ThenReturned 'One'
+    }
+}
+
+Describe 'Get-BMPipeline.when WhatIfPreference is true' {
+    It 'should still return pipelines' {
+        Init
+        $p = GivenPipeline 'One'
+        WhenGettingPipeline -ForPipeline $p.Pipeline_Id -WhatIf
         ThenReturned 'One'
     }
 }


### PR DESCRIPTION
Anything that uses the native API to retrieve records fails if a user's WhatIfPreference is true since the native API uses POSTs for some reads. 

Also, discovered we weren't setting an environment's parent in New-BMEnvironment. Oops.