### PR TITLE
Updating to support BuildMaster 6.2.33.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,9 @@
-/PSModules/
 /.output/
 /.vscode/
+/BuildMasterAutomation/CHANGELOG.md
 /BuildMasterAutomation/LICENSE
 /BuildMasterAutomation/NOTICE
 /BuildMasterAutomation/README.md
-/BuildMasterAutomation/CHANGELOG.md
+/PSModules/
 *.log
-.psgallerykey
 *.orig

--- a/BuildMasterAutomation/BuildMasterAutomation.psd1
+++ b/BuildMasterAutomation/BuildMasterAutomation.psd1
@@ -28,7 +28,11 @@
 
     # Description of the functionality provided by this module
     Description = @'
-The BuildMasterAutomation module is a PowerShell module for working with BuildMaster web APIs. BuildMaster is an application deployment automation tool by Inedo software. This module wraps its web APIs in a PowerShell interface. It allows you to read and create applications, releases, packages, etc. If this module doesn't have a function for a specific API endpoint, it has generic `Invoke-BMRestMethod` and `Invoke-BMNativeApimethod` functions that take the pain out of creating the proper web requests.
+BuildMasterAutomation is a PowerShell module for working with BuildMaster web APIs. BuildMaster is an application
+build and deployment automation tool by Inedo software. This module wraps its web APIs in a PowerShell interface. The
+module's functions allow you to read and create applications, releases, builds, etc. If this module doesn't have a
+function for a specific API endpoint, it has generic `Invoke-BMRestMethod` and `Invoke-BMNativeApimethod` functions that
+take the pain out of creating the proper web requests.
 '@
 
     # Minimum version of the Windows PowerShell engine required by this module
@@ -63,46 +67,63 @@ The BuildMasterAutomation module is a PowerShell module for working with BuildMa
 
     # Format files (.ps1xml) to be loaded when importing this module
     FormatsToProcess = @(
-                            'Formats\Inedo.BuildMaster.Server.ps1xml'
-                        )
+        'Formats\Inedo.BuildMaster.Server.ps1xml'
+        'Formats\Inedo.BuildMaster.RaftItem.ps1xml'
+    )
 
     # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
     # NestedModules = @()
 
     # Functions to export from this module
     FunctionsToExport = @(
-                            'Add-BMObjectParameter',
-                            'Disable-BMApplication',
-                            'Disable-BMEnvironment',
-                            'Enable-BMEnvironment',
-                            'Get-BMApplication',
-                            'Get-BMApplicationGroup',
-                            'Get-BMDeployment',
-                            'Get-BMEnvironment',
-                            'Get-BMRelease',
-                            'Get-BMPackage',
-                            'Get-BMPipeline',
-                            'Get-BMServer',
-                            'Get-BMServerRole',
-                            'Get-BMVariable',
-                            'Invoke-BMNativeApiMethod',
-                            'Invoke-BMRestMethod',
-                            'New-BMApplication',
-                            'New-BMEnvironment',
-                            'New-BMPipeline',
-                            'New-BMRelease',
-                            'New-BMPackage',
-                            'New-BMSession',
-                            'New-BMServer',
-                            'New-BMServerRole',
-                            'Publish-BMReleasePackage',
-                            'Remove-BMServer',
-                            'Remove-BMServerRole',
-                            'Remove-BMVariable',
-                            'Set-BMRelease',
-                            'Set-BMVariable',
-                            'Stop-BMRelease'
-                         )
+        'Add-BMObjectParameter',
+        'Add-BMParameter',
+        'ConvertFrom-BMNativeApiByteValue',
+        'ConvertTo-BMNativeApiByteValue',
+        'Disable-BMApplication',
+        'Disable-BMEnvironment',
+        'Enable-BMEnvironment',
+        'Get-BMApplication',
+        'Get-BMApplicationGroup',
+        'Get-BMBuild',
+        'Get-BMDeployment',
+        'Get-BMEnvironment',
+        'Get-BMPackage',
+        'Get-BMRelease',
+        'Get-BMObjectName',
+        'Get-BMPipeline',
+        'Get-BMRaft',
+        'Get-BMRaftItem',
+        'Get-BMServer',
+        'Get-BMServerRole',
+        'Get-BMVariable',
+        'Invoke-BMNativeApiMethod',
+        'Invoke-BMRestMethod',
+        'New-BMApplication',
+        'New-BMBuild',
+        'New-BMEnvironment',
+        'New-BMPackage',
+        'New-BMRelease',
+        'New-BMPipelinePostDeploymentOptionsObject',
+        'New-BMPipelineStageObject',
+        'New-BMPipelineStageTargetObject',
+        'New-BMSession',
+        'New-BMServer',
+        'New-BMServerRole',
+        'Publish-BMReleaseBuild',
+        'Publish-BMReleasePackage',
+        'Remove-BMApplication',
+        'Remove-BMRaftItem',
+        'Remove-BMPipeline',
+        'Remove-BMServer',
+        'Remove-BMServerRole',
+        'Remove-BMVariable',
+        'Set-BMPipeline',
+        'Set-BMRaftItem',
+        'Set-BMRelease',
+        'Set-BMVariable',
+        'Stop-BMRelease'
+    )
 
     # Cmdlets to export from this module
     CmdletsToExport = @()

--- a/BuildMasterAutomation/BuildMasterAutomation.psm1
+++ b/BuildMasterAutomation/BuildMasterAutomation.psm1
@@ -1,5 +1,41 @@
 
+$script:defaultRaftId = 1
+
+enum BMRaftItemTypeCode
+{
+    Module = 3
+    Script = 4
+    DeploymentPlan = 6
+    Pipeline = 8
+}
+
 Add-Type -AssemblyName 'System.Web'
+
+$script:warnings = @{}
+
+function Write-WarningOnce
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, Position=0, ParameterSetName='Message', ValueFromPipeline)]
+        [String] $Message
+    )
+
+    process
+    {
+        Set-StrictMode -Version 'Latest'
+        Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+
+        if( $script:warnings[$Message] )
+        {
+            return
+        }
+
+        Write-Warning -Message $Message
+        $script:warnings[$Message] = $true
+    }
+}
+
 
 $functionsDir = Join-Path -Path $PSScriptRoot -ChildPath 'Functions'
 if( (Test-Path -Path $functionsDir -PathType Container) )

--- a/BuildMasterAutomation/Formats/Inedo.BuildMaster.RaftItem.ps1xml
+++ b/BuildMasterAutomation/Formats/Inedo.BuildMaster.RaftItem.ps1xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+   Copyright 2016 - 2018 WebMD Health Services
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<Configuration>
+    <ViewDefinitions>
+        <View>
+            <Name>Inedo.BuildMaster.RaftItem.Table</Name>
+            <ViewSelectedBy>
+                <TypeName>Inedo.BuildMaster.RaftItem</TypeName>
+            </ViewSelectedBy>
+            <TableControl>
+                <TableRowEntries>
+                    <TableRowEntry>
+                        <TableColumnItems>
+                            <TableColumnItem>
+                                <PropertyName>Raft_Id</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>RaftItem_Id</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>RaftItem_Name</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>RaftItemType_Code</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>Type</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>Application_Id</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>Application_Name</PropertyName>
+                            </TableColumnItem>
+                        </TableColumnItems>
+                    </TableRowEntry>
+                </TableRowEntries>
+            </TableControl>
+        </View>
+    </ViewDefinitions>
+</Configuration>

--- a/BuildMasterAutomation/Functions/Add-BMParameter.ps1
+++ b/BuildMasterAutomation/Functions/Add-BMParameter.ps1
@@ -1,0 +1,88 @@
+
+function Add-BMParameter
+{
+    <#
+    .SYNOPSIS
+    Adds values to a parameter hashtable (i.e. a hashtable used as the body of a request to a BuildMaster API endpoint).
+
+    .DESCRIPTION
+    The `Add-BMParameter` function adds values to a parameter hashtable. Pipe the hashtable to the function (or pass it
+    to the `Parameter` parameter). Pass the parameter name to the `Name` parameter and the value to the `Value`
+    parameter. If the value is not null, it will be added to the hashtable.
+
+    This function lets you simplify adding optional parameters to a parameter hashtable. Instead of:
+
+         if ($null -ne $Value)
+         {
+            $parameters[$Name] = $Value
+         }
+
+    this function lets you write:
+
+        $parameters | Add-BMParameter -Name $Name -Value $Value
+
+    It also lets you chain multiple parameters together by using the `-PassThru` switch:
+
+        $parameters |
+            Add-BMParameter -Name $Name1 -Value $Value1 -PassThru |
+            Add-BMParameter -Name $Name2 -Value $Value2 -PassThru |
+            Add-BMParameter -Name $Name3 -Value $Value3
+
+    .EXAMPLE
+    $parameters | Add-BMParameter -Name $Name -Value $Value
+
+    Demonstrates how to add an optional parameter to the parameter hashtable `$parameters`. In this case, if `$Value`
+    is not null, `Add-BMParameter` adds `$Value` into `$parameters` using key `$Name`, e.g.
+    `$parameters[$Name] = $Value`.
+
+    .EXAMPLE
+    $parameters | Add-BMParameter -Name $Name -Value $Value -PassThru | Add-BMParameter -Name $Name2 -Value $Value2
+
+    Demonstrates how you can add multiple parameters to a parameter hashtable by using the `-PassThru` switch, which
+    returns the parameter hashtable, which be piped to `Add-BMParameter`.
+    #>
+    [CmdletBinding()]
+    param(
+        # The hashtable to add the parameter to.
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [hashtable] $Parameter,
+
+        # The name of the parameter.
+        [Parameter(Mandatory)]
+        [String] $Name,
+
+        # The value of the parameter. If the value is not null, it is added to the `$Parameter` hashtable using the
+        # name argument as the key.
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [AllowNull()]
+        [Object] $Value,
+
+        # If set, returns the hashtable piped (or passed to parameter `$Parameter). This lets you create a pipeline of
+        # calls to `Add-BMParameter`.
+        [switch] $PassThru
+    )
+
+    process
+    {
+        Set-StrictMode -Version 'Latest'
+        Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+
+        if ($null -ne $Value)
+        {
+            if ($Value -is [hashtable])
+            {
+                $Parameter[$Name] = $Value[$Name]
+            }
+            $Parameter[$Name] = $Value
+        }
+
+        if ($PassThru)
+        {
+            return $Parameter
+        }
+    }
+
+
+}
+

--- a/BuildMasterAutomation/Functions/Add-BMPipelineMember.ps1
+++ b/BuildMasterAutomation/Functions/Add-BMPipelineMember.ps1
@@ -1,0 +1,36 @@
+
+function Add-BMPipelineMember
+{
+    <#
+    .SYNOPSIS
+    Adds `Pipeline_Name` and `Pipeline_Id` properties to an object.
+
+    .DESCRIPTION
+    In BuildMaster 6.2, pipeline objects are now rafts and now have `RaftItem_Name` and `RaftItem_Id` properties instead
+    of `Pipeline_Name` and `Pipeline_Id` objects. This function adds `Pipeline_Name` and `Pipeline_Id` *alias*
+    properties to an object that alias the `RaftItem_Name` and `RaftItem_Id` properties, respectively. You should only
+    pipe raft items that represent pipelines to this function. It does *not* validate the incoming object.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [Object] $Pipeline,
+
+        [switch] $PassThru
+    )
+
+    process
+    {
+        Set-StrictMode -Version 'Latest'
+        Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+
+        if (-not $Pipeline)
+        {
+            return
+        }
+
+        $Pipeline |
+            Add-Member -Name 'Pipeline_Name' -MemberType AliasProperty -Value 'RaftItem_Name' -PassThru |
+            Add-Member -Name 'Pipeline_Id' -MemberType AliasProperty -Value 'RaftItem_Id' -PassThru:$PassThru
+    }
+}

--- a/BuildMasterAutomation/Functions/Add-PSTypeName.ps1
+++ b/BuildMasterAutomation/Functions/Add-PSTypeName.ps1
@@ -1,26 +1,28 @@
-# Copyright 2016 - 2018 WebMD Health Services
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 function Add-PSTypeName
 {
+    <#
+    .SYNOPSIS
+    Adds a BuildMaster type name to an object.
+
+    .DESCRIPTION
+    The `Add-PSTypeName` function adds BuildMaster type names to an object. These types don't actually exist. The type
+    names are used by PowerShell to decide what formats to use when displaying an object.
+
+    If the `Server` switch is set, it adds a `Inedo.BuildMaster.Server` type name.
+
+    If the `RaftItem` switch is set, it adds a `Inedo.BuildMaster.RaftItem` type name.
+    #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory,ValueFromPipeline)]
-        [object]$InputObject,
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [Object] $InputObject,
 
-        [Parameter(Mandatory,ParameterSetName='Server')]
-        [Switch]$Server
+        [Parameter(Mandatory, ParameterSetName='Server')]
+        [switch] $Server,
+
+        [Parameter(Mandatory, ParameterSetName='RaftItem')]
+        [switch] $RaftItem
     )
 
     process
@@ -29,6 +31,6 @@ function Add-PSTypeName
 
         $typeName = 'Inedo.BuildMaster.{0}' -f $PSCmdlet.ParameterSetName
         $InputObject.pstypenames.Add( $typeName )
-        $InputObject
+        $InputObject | Write-Output
     }
 }

--- a/BuildMasterAutomation/Functions/ConvertFrom-BMNativeApiByteValue.ps1
+++ b/BuildMasterAutomation/Functions/ConvertFrom-BMNativeApiByteValue.ps1
@@ -1,0 +1,44 @@
+
+function ConvertFrom-BMNativeApiByteValue
+{
+    <#
+    .SYNOPSIS
+    Converts a binary value returned from the BuildMaster native API as a `byte[]` object to a string.
+
+    .DESCRIPTION
+    Some of the objects returned by the BuildMaster native API have properties that are typed as byte arrays, i.e.
+    `byte[]`.This function converts these values into strings. Pipe the value to the function (or pass it to the
+    `InputObject` parameter).
+
+    .EXAMPLE
+    ConvertFrom-BMNativeApiByteValue 'ZW1wdHk='
+
+    Demonstrates how to convert a `byte[]` value returned by a BuildMaster native API into its original string/text.
+
+    .EXAMPLE
+    'ZW1wdHk=' | ConvertFrom-BMNativeApiByteValue
+
+    Demonstrates that you can pipe values to `ConvertFrom-BMNativeApiByteValue`.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline, Position=0)]
+        [String] $InputObject
+    )
+
+    begin
+    {
+        Set-StrictMode -Version 'Latest'
+        Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+    }
+
+    process
+    {
+        $bytes = [Convert]::FromBase64String($InputObject)
+        [Text.Encoding]::UTF8.GetString($bytes) | Write-Output
+    }
+
+    end
+    {
+    }
+}

--- a/BuildMasterAutomation/Functions/ConvertTo-BMNativeApiByteValue.ps1
+++ b/BuildMasterAutomation/Functions/ConvertTo-BMNativeApiByteValue.ps1
@@ -1,0 +1,52 @@
+
+function ConvertTo-BMNativeApiByteValue
+{
+    <#
+    .SYNOPSIS
+    Converts a string into a value that can be passed to a `byte[]` parameter in the BuildMaster native API.
+
+    .DESCRIPTION
+    Some of the parameters of the BuildMaster native API are typed as `byte[]` object. This function converts strings
+    into a value that can be passed as one of these parameters. Pipe the string you want to convert (or pass it to the
+    `InputObject` parameter). The function will return a value that you can pass to the BuildMaster API.
+
+    If you pipe multiple strings to `ConvertTo-BMNativeApiByteValue`, the strings will be concatenated together before
+    conversion.
+
+    .EXAMPLE
+    ConvertTo-BMNativeApiByteValue 'hello example'
+
+    Demonstrates how to convert a string into value that can be passed to a `byte[]`-typed parameter on the BuildMaster
+    native API.
+
+    .EXAMPLE
+    'hello','example' | ConvertTo-BMNativeApiByteValue
+
+    Demonstrates that you can pipe strings to `ConvertTo-BMNativeApiByteValue`. All the strings piped in will be
+    concatenated together before conversion.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline, Position=0)]
+        [String] $InputObject
+    )
+
+    begin
+    {
+        Set-StrictMode -Version 'Latest'
+        Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+
+        $allStrings = [Text.StringBuilder]::New()
+    }
+
+    process
+    {
+        [void] $allStrings.Append($InputObject)
+    }
+
+    end
+    {
+        $stringBytes = [Text.Encoding]::UTF8.GetBytes($allStrings.ToString())
+        [Convert]::ToBase64String($stringBytes) | Write-Output
+    }
+}

--- a/BuildMasterAutomation/Functions/Get-BMApplication.ps1
+++ b/BuildMasterAutomation/Functions/Get-BMApplication.ps1
@@ -4,12 +4,12 @@ function Get-BMApplication
     <#
     .SYNOPSIS
     Gets BuildMaster applications.
-    
+
     .DESCRIPTION
     The `Get-BMApplication` function gets all active applications from an instance of BuildMaster. Use the `Force` switch to include inactive applications. To get a specific application, pass the name to the `Name` parameter. Active and inactive applications are returned. If an application with the name doesn't exist, you'll get nothing back.
-    
-    Uses the BuildMaster native API, which can change without notice between releases. By default, this function returns *all* applications. 
-    
+
+    Uses the BuildMaster native API, which can change without notice between releases. By default, this function returns *all* applications.
+
     .EXAMPLE
     Get-BMApplication -Session $session
 
@@ -51,10 +51,10 @@ function Get-BMApplication
     $parameters = @{
                         Application_Count = 0;
                         IncludeInactive_Indicator = ($Force.IsPresent -or $PSCmdlet.ParameterSetName -eq 'SpecificApplication');
-                   } 
+                   }
 
     Invoke-BMNativeApiMethod -Session $Session -Name 'Applications_GetApplications' -Parameter $parameters -Method Post |
-        Where-Object { 
+        Where-Object {
             if( $Name )
             {
                 return $_.Application_Name -eq $Name

--- a/BuildMasterAutomation/Functions/Get-BMDeployment.ps1
+++ b/BuildMasterAutomation/Functions/Get-BMDeployment.ps1
@@ -6,15 +6,11 @@ function Get-BMDeployment
     Gets a deployment from BuildMaster.
 
     .DESCRIPTION
-    The `Get-BMDeployment` function gets deployments in BuildMaster. It uses the [Release and Package Deployment API](http://inedo.com/support/documentation/buildmaster/reference/api/release-and-package).
+    The `Get-BMDeployment` function gets a deployment from BuildMaster. Pass the deployment id or deployment object to
+    the `Deployment` parameter. That deployment will be returned.
 
-    To get a specific deployment, pass a deploymentID.
-
-    To get all the deployments for a specific package, pass a package object to the `Package` parameter (a package object must have a `packageId` or `packageNumber` property).
-
-    To get all the deployments for a specific release, pass a release object to the `Release` parameter (a release object must have a `releaseId` or `releaseName` property).
-
-    To get all the deployments for a specific application, pass an application object to the `Application` parameter (an application object must have an `applicationId` or `applicationName` property).
+    This function uses the
+    [Release and Build Deployment API](https://docs.inedo.com/docs/buildmaster-reference-api-release-and-build).
 
     .EXAMPLE
     Get-BMDeployment -Session $session
@@ -22,67 +18,21 @@ function Get-BMDeployment
     Demonstrates how to get all deployments from the instance of BuildMaster.
 
     .EXAMPLE
-    Get-BMDeployment -Session $session -ID $deployment
+    Get-BMDeployment -Session $session -Deploytment $deployment
 
-    Demonstrates how to get a specific deployment by passing a deployment object to the `Deployment` parameter. The `Get-BMDeployment` function looks for an `id` property on the object.
-
-    .EXAMPLE
-    Get-BMDeployment -Session $session -Package $package
-
-    Demonstrates how to get all deployments for a package by passing a package object to the `Package` parameter. The `Get-BMDeployment` function looks for an `id` or `number` property on the object.
-
-    .EXAMPLE
-    Get-BMDeployment -Session $session -Release $release
-
-    Demonstrates how to get all deployments for a release by passing a release object to the `Release` parameter. The `Get-BMDeployment` function looks for an `id` or `name` property on the object.
-
-    .EXAMPLE
-    Get-BMDeployment -Session $session -Application $app
-
-    Demonstrates how to get all deployments for an application by passing an application object to the `Application` parameter. The `Get-BMDeployment` function looks for an `id` or `name` property on the object.
-
-    .EXAMPLE
-    Get-BMDeployment -Session $session -Application 34
-
-    Demonstrates how to get all deployments for an application by passing its ID to the `Application` parameter.
+    Demonstrates how to get a specific deployment by passing a deployment object to the `Deployment` parameter. The
+    `Get-BMDeployment` function looks for an `id` property on the object.
     #>
-    [CmdletBinding(DefaultParameterSetName='AllDeployments')]
+    [CmdletBinding()]
     param(
+        # The session to BuildMaster. Use `New-BMSession` to create a session.
         [Parameter(Mandatory)]
-        [object]
-        # A session object that contains the settings to use to connect to BuildMaster. Use `New-BMSession` to create session objects.
-        $Session,
+        [Object] $Session,
 
-        [Parameter(Mandatory,ParameterSetName='ByDeployment')]
-        [int]
-        # The deployment to get. You can pass:
-        #
-        # * A deployment ID (as an integer)
-        $ID,
-
-        [Parameter(Mandatory,ParameterSetName='ByPackage')]
-        [object]
-        # The package whose deployments to get. You can pass:
-        #
-        # * A package ID as an integer
-        # * A package name/number as a string.
-        $Package,
-
-        [Parameter(Mandatory,ParameterSetName='ByRelease')]
-        [object]
-        # The release whose deployments to get. You can pass:
-        #
-        # * The release ID as an integer.
-        # * The release name as a string.
-        $Release,
-
-        [Parameter(Mandatory,ParameterSetName='ByApplication')]
-        [object]
-        # The application whose deployments to get. You can pass:
-        #
-        # * The application ID as an integer.
-        # * The application name as a string.
-        $Application
+        # The deployment to get. You can pass a deployment id or object.
+        [Parameter(Mandatory)]
+        [Alias('ID')]
+        [Object] $Deployment
     )
 
     process
@@ -90,31 +40,9 @@ function Get-BMDeployment
         Set-StrictMode -Version 'Latest'
         Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
 
-        $parameter = @{ }
-        if( $PSCmdlet.ParameterSetName -eq 'ByDeployment' )
-        {
-            $parameter | Add-BMObjectParameter -Name 'deployment' -Value $ID
-        }
-        elseif( $PSCmdlet.ParameterSetName -eq 'ByPackage' )
-        {
-            if( $Package -is [string] )
-            {
-                $parameter['packageNumber'] = $Package
-            }
-            else
-            {
-                $parameter | Add-BMObjectParameter -Name 'package' -Value $Package
-            }
-        }
-        elseif( $PSCmdlet.ParameterSetName -eq 'ByRelease' )
-        {
-            $parameter | Add-BMObjectParameter -Name 'release' -Value $Release
-        }
-        elseif( $PSCmdlet.ParameterSetName -eq 'ByApplication' )
-        {
-            $parameter | Add-BMObjectParameter -Name 'application' -Value $Application
-        }
-
-        Invoke-BMRestMethod -Session $Session -Name 'releases/packages/deployments' -Parameter $parameter -Method Post
+        $parameter =
+            @{ } |
+            Add-BMObjectParameter -Name 'deployment' -Value $Deployment -PassThru
+        Invoke-BMRestMethod -Session $Session -Name 'releases/builds/deployments' -Parameter $parameter -Method Post
     }
 }

--- a/BuildMasterAutomation/Functions/Get-BMObjectName.ps1
+++ b/BuildMasterAutomation/Functions/Get-BMObjectName.ps1
@@ -1,0 +1,81 @@
+
+function Get-BMObjectName
+{
+    <#
+    .SYNOPSIS
+    Returns the name of an object that was returned by the BuildMaster API.
+
+    .DESCRIPTION
+    The BuildMasterAutomation module allows you to pass ids, names, or objects as the value to many parameters. Use the
+    `Get-BMObjectName` function to get the name of one of these parameter values.
+
+    If passed a string or an id, those will be returned as the name. Otherwise, the function looks for a `Name`
+    property, a property matching wildcard `*_Name`, and then a property matching wildcard `*Name`, and returns the
+    value of the first property found. If no properties are found, the function writes an error.
+
+    If an object has multiple properties that could be its name, pass the name of the property to use to the
+    `PropertyName` function.
+
+    .EXAMPLE
+    $app | Get-BMObjectName
+
+    Demonstrates how to get the name of an application object. In this case, the value of the application's
+    `Application_Name` property will be returned.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [Object] $InputObject,
+
+        [String] $PropertyName
+    )
+
+    process
+    {
+        Set-StrictMode -Version 'Latest'
+        Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+
+        if (-not ($InputObject | Test-BMObject))
+        {
+            return $InputObject
+        }
+
+        if (-not $PropertyName)
+        {
+            $PropertyName = 'Name'
+        }
+
+        if ($InputObject | Get-Member -Name $PropertyName)
+        {
+            return $InputObject.$PropertyName
+        }
+
+        if ($PSBoundParameters.ContainsKey('PropertyName'))
+        {
+            Write-Error -Message "Object does not have a ""$($PropertyName)"" property."
+            return
+        }
+
+        $nameProperty = $InputObject | Get-Member -Name '*_Name'
+        if (-not $nameProperty)
+        {
+            $nameProperty = $InputObject | Get-Member -Name '*Name'
+            if (-not $nameProperty)
+            {
+                Write-Error "Object does not have a name property." -ErrorAction $ErrorActionPreference
+                return
+            }
+        }
+
+        $nameCount = ($nameProperty | Measure-Object).Count
+        if ($nameCount -gt 1)
+        {
+            $msg = "Object has multiple name properties: ""$($nameProperty -join '", "')"". Use the " +
+                   '"PropertyName" parameter to set the name of the property to get.'
+            Write-Error $msg -ErrorAction $ErrorActionPreference
+            return
+        }
+
+        return $InputObject.($nameProperty.Name)
+    }
+}

--- a/BuildMasterAutomation/Functions/Get-BMPackage.ps1
+++ b/BuildMasterAutomation/Functions/Get-BMPackage.ps1
@@ -1,0 +1,37 @@
+
+function Get-BMPackage
+{
+    <#
+    .SYNOPSIS
+    Obsolete. Use `Get-BMBuild` instead.
+    #>
+    [CmdletBinding(DefaultParameterSetName='AllBuilds')]
+    param(
+        [Parameter(Mandatory)]
+        [Object] $Session,
+
+        [Parameter(Mandatory, ParameterSetName='SpecificPackage')]
+        [Object] $Package,
+
+        [Parameter(Mandatory, ParameterSetName='ReleasePackages')]
+        [Object] $Release
+    )
+
+    Set-StrictMode -Version 'Latest'
+    Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+
+    $msg = 'The BuildMasterAutomation module''s ""Get-BMPackage"" function is obsolete and will be removed in a ' +
+           'future version of BuildMasterAutomation. Use the "Get-BMBuild" function instead.'
+    Write-WarningOnce $msg
+
+    $getArgs = @{}
+    if ($PSCmdlet.ParameterSetName -eq 'SpecificPackage')
+    {
+        $getArgs['Build'] = $Package
+    }
+    elseif( $PSCmdlet.ParameterSetName -eq 'ReleasePackages')
+    {
+        $getArgs['Release'] = $Release
+    }
+    Get-BMBuild -Session $Session @getArgs
+}

--- a/BuildMasterAutomation/Functions/Get-BMRaft.ps1
+++ b/BuildMasterAutomation/Functions/Get-BMRaft.ps1
@@ -1,0 +1,28 @@
+
+function Get-BMRaft
+{
+    <#
+    .SYNOPSIS
+    Gets all the rafts from BuildMaster.
+
+    .DESCRIPTION
+    The `Get-BMRaft` function returns all rafts from BuildMaster. It uses the native API.
+
+    .EXAMPLE
+    Get-BMRaft -Session $session
+
+    Demonstrates how to use `Get-BMRaft` to get all rafts from BuildMaster.
+    #>
+    [CmdletBinding()]
+    param(
+        # A session object that represents the BuildMaster instance to use. Use the `New-BMSession` function to create
+        # session objects.
+        [Parameter(Mandatory)]
+        [Object] $Session
+    )
+
+    Set-StrictMode -Version 'Latest'
+    Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+
+    Invoke-BMNativeApiMethod -Session $Session -Name 'Rafts_GetRafts'
+}

--- a/BuildMasterAutomation/Functions/Get-BMRaftItem.ps1
+++ b/BuildMasterAutomation/Functions/Get-BMRaftItem.ps1
@@ -1,0 +1,109 @@
+
+function Get-BMRaftItem
+{
+    <#
+    .SYNOPSIS
+    Gets raft items from BuildMaster.
+
+    .DESCRIPTION
+    The `Get-RaftItem` function gets all the raft items in a specific raft. Pass the raft ID or object to the `Raft`
+    parameter. By default, all raft items in that raft are returned. To return an item with a specific name, pass the
+    name to the `Name` parameter (wildcards accepted). To get only raft items used by a specific application, pass the
+    application id, name, or object to the `Application` parameter. To get a specific type of raft item, pass the type
+    to the `TypeCode` parameter.
+
+    If multiple arguments are passed among the `Name`, `Application`, and `TypeCode` parameters, the `Get-BMRaftItem`
+    function returns only raft items that meets *all* search criteria.
+
+    .EXAMPLE
+    Get-BMRaftItem -Session $session -Raft $raftId
+
+    Demonstrates how to get all the items from a specific raft.
+
+    .EXAMPLE
+    Get-BMRaftItem -Session $session -Raft $raftId -Name '*yolo*'
+
+    Demonstrates how to get raft items from a specific raft whose name matches a specific wildcard pattern. In this
+    case, all raft items whose names match `*yolo*` will be returned.
+
+    .EXAMPLE
+    Get-BMRaftItem -Session $session -Raft $raftId -Application $appOrIdOrName
+
+    Demonstrates how to get raft items from a specific raft used by a specific application. You can pass an application
+    id, name, or object to the `-Application` parameter.
+
+    .EXAMPLE
+    Get-BMRaftItem -Session $session -Raft $raftId -TypeCode Pipeline
+
+    Demonstrates how to get raft items from a specific raft with a specific type. In this case, all pipeline raft items
+    are returned.
+    #>
+    [CmdletBinding()]
+    param(
+        # A session object to the BuildMaster instance to use. Use the `New-BMSession` function to create a session.
+        [Parameter(Mandatory)]
+        [Object] $Session,
+
+        # The raft id, name, or object whose items to return.
+        [Parameter(Mandatory)]
+        [Object] $Raft,
+
+        # The name of the item to get. Supports wildcards.
+        [String] $Name,
+
+        # The application id, name or object whose items to get.
+        [Object] $Application,
+
+        # The raft item types to return.
+        [BMRaftItemTypeCode] $TypeCode
+    )
+
+    Set-StrictMode -Version 'Latest'
+    Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+    $WhatIfPreference = $false # Gets items, but the API requires a POST.
+
+    $getArgs = @{}
+
+    $getArgs |
+        Add-BMObjectParameter -Name 'Raft' -Value $Raft -ForNativeApi -PassThru |
+        Add-BMObjectParameter -Name 'Application' -Value $Application -ForNativeApi -PassThru |
+        Add-BMParameter -Name 'RaftItemType_Code' -Value ([int]$TypeCode)
+
+    $searching = [wildcardpattern]::ContainsWildcardCharacters($Name)
+    if ($Name -and -not $searching)
+    {
+        $getArgs | Add-BMParameter -Name 'RaftItem_Name' -Value $Name
+    }
+
+    $raftItems = $null
+    Invoke-BMNativeApiMethod -Session $Session -Name 'Rafts_GetRaftItems' -Parameter $getArgs -Method Post |
+        Where-Object {
+            if (-not $Name -or -not $searching)
+            {
+                return $true
+            }
+
+            return $_.RaftItem_Name -like $Name
+        } |
+        Tee-Object -Variable 'raftItems' |
+        Add-PSTypeName -RaftItem |
+        Add-Member -Name 'Type' -MemberType ScriptProperty -Value {
+                switch ($this.RaftItemType_Code)
+                {
+                    3 { return 'Module' }
+                    4 { return 'Script' }
+                    6 { return 'DeploymentPlan' }
+                    8 { return 'Pipeline' }
+                    default { return $this.RaftItemType_Code }
+                }
+            } -PassThru |
+        Add-Member -Name 'Content' -MemberType ScriptProperty -Value {
+                $this.Content_Bytes | ConvertFrom-BMNativeApiByteValue
+            } -PassThru
+
+    if ($Name -and -not $searching -and -not $raftItems)
+    {
+        $msg = "$($TypeCode | Get-BMRaftTypeDisplayName) ""$($Name)"" doesn't exist."
+        Write-Error -Message $msg -ErrorAction $ErrorActionPreference
+    }
+}

--- a/BuildMasterAutomation/Functions/Get-BMRaftTypeDisplayName.ps1
+++ b/BuildMasterAutomation/Functions/Get-BMRaftTypeDisplayName.ps1
@@ -1,0 +1,18 @@
+
+function Get-BMRaftTypeDisplayName
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [BMRaftItemTypeCode] $TypeCode
+    )
+
+    process
+    {
+        switch ($TypeCode)
+        {
+            'DeploymentPlan' { return 'Deployment Plan' }
+            default { $TypeCode.ToString() }
+        }
+    }
+}

--- a/BuildMasterAutomation/Functions/Get-BMRelease.ps1
+++ b/BuildMasterAutomation/Functions/Get-BMRelease.ps1
@@ -6,7 +6,8 @@ function Get-BMRelease
     Gets the release for an application in BuildMaster.
 
     .DESCRIPTION
-    The `Get-BMRelease` function gets releases in BuildMaster. It uses the [Release and Package Deployment API](http://inedo.com/support/documentation/buildmaster/reference/api/release-and-package). 
+    The `Get-BMRelease` function gets releases in BuildMaster. It uses the
+    [Release and Build Deployment API](https://docs.inedo.com/docs/buildmaster-reference-api-release-and-build).
 
     To get a specific release, pass a release object, release ID, or release name to the `Release` parameter.
 
@@ -25,12 +26,12 @@ function Get-BMRelease
     .EXAMPLE
     Get-BMRelease -Session $session -Application 34
 
-    Demonstrates how to get all the releases for an application by passing its ID to the `Application` parameter. 
+    Demonstrates how to get all the releases for an application by passing its ID to the `Application` parameter.
 
     .EXAMPLE
     Get-BMRelease -Session $session -Application 'BuildMasterAutomation'
 
-    Demonstrates how to get all the releases for an application by passing its name to the `Application` parameter. 
+    Demonstrates how to get all the releases for an application by passing its name to the `Application` parameter.
 
     .EXAMPLE
     Get-BMRelease -Session $session -Application 'BuildMasterAutomation' -Name '4.1'
@@ -63,7 +64,7 @@ function Get-BMRelease
         $Application,
 
         [string]
-        # The name of the release to get. 
+        # The name of the release to get.
         $Name
     )
 
@@ -72,8 +73,8 @@ function Get-BMRelease
         Set-StrictMode -Version 'Latest'
         Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
 
-        $parameter = @{ } 
-        
+        $parameter = @{ }
+
         if( $PSCmdlet.ParameterSetName -eq 'ByRelease' )
         {
             $parameter | Add-BMObjectParameter -Name 'release' -Value $Release

--- a/BuildMasterAutomation/Functions/Get-BMServer.ps1
+++ b/BuildMasterAutomation/Functions/Get-BMServer.ps1
@@ -37,6 +37,7 @@ function Get-BMServer
 
     Set-StrictMode -Version 'Latest'
     Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+    $WhatIfPreference = $false
 
     $servers = $null
 
@@ -56,7 +57,7 @@ function Get-BMServer
             $server = $_
             foreach( $memberName in @( 'name', 'roles', 'environments', 'serverType', 'hostName', 'port', 'encryptionType', 'encryptionKey', 'requireSsl', 'credentialsName', 'tempPath', 'wsManUrl', 'active', 'variables' ) )
             {
-                if( -not ($server | Get-Member -Name $memberName) ) 
+                if( -not ($server | Get-Member -Name $memberName) )
                 {
                     $server | Add-Member -MemberType NoteProperty -Name $memberName -Value $null
                 }
@@ -68,13 +69,13 @@ function Get-BMServer
             }
             $server
         } |
-        Tee-Object -Variable 'servers' 
+        Tee-Object -Variable 'servers'
 
     if( $PSCmdlet.ParameterSetName -eq 'All' -or $servers )
     {
         return
     }
-    
+
     if( -not [wildcardpattern]::ContainsWildcardCharacters($Name) )
     {
         Write-Error -Message ('Server "{0}" does not exist.' -f $Name) -ErrorAction $ErrorActionPreference

--- a/BuildMasterAutomation/Functions/Invoke-BMRestMethod.ps1
+++ b/BuildMasterAutomation/Functions/Invoke-BMRestMethod.ps1
@@ -6,60 +6,64 @@ function Invoke-BMRestMethod
     Invokes a BuildMaster REST method.
 
     .DESCRIPTION
-    The `Invoke-BMRestMethod` invokes a BuildMaster REST API method. You pass the path to the endpoint (everything after `/api/`) via the `Name` parameter, the HTTP method to use via the `Method` parameter, and the parameters to pass in the body of the request via the `Parameter` parameter.  This function converts the `Parameter` hashtable to a URL-encoded query string and sends it in the body of the request. You can send the parameters as JSON by adding the `AsJson` parameter. You can pass your own custom body to the `Body` parameter. If you do, make sure you set an appropriate content type for the request with the `ContentType` parameter.
+    The `Invoke-BMRestMethod` invokes a BuildMaster REST API method. You pass the path to the endpoint (everything after
+    `/api/`) via the `Name` parameter, the HTTP method to use via the `Method` parameter, and the parameters to pass in
+    the body of the request via the `Parameter` parameter.  This function converts the `Parameter` hashtable to a
+    URL-encoded query string and sends it in the body of the request. You can send the parameters as JSON by adding the
+    `AsJson` parameter. You can pass your own custom body to the `Body` parameter. If you do, make sure you set an
+    appropriate content type for the request with the `ContentType` parameter.
 
-    You also need to pass an object that represents the BuildMaster instance and API key to use when connecting via the `Session` parameter. Use the `New-BMSession` function to create a session object.
+    You also need to pass an object that represents the BuildMaster instance and API key to use when connecting via the
+    `Session` parameter. Use the `New-BMSession` function to create a session object.
 
     When using the `WhatIf` parameter, only web requests that use the `Get` HTTP method are made.
     #>
-    [CmdletBinding(SupportsShouldProcess=$true,DefaultParameterSetName='NoBody')]
+    [CmdletBinding(SupportsShouldProcess, DefaultParameterSetName='NoBody')]
     param(
-        [Parameter(Mandatory=$true)]
-        [object]
-        # A session object that represents the BuildMaster instance to use. Use the `New-BMSession` function to create session objects.
-        $Session,
+        # A session object to BuildMaster. Use the `New-BMSession` function to create a session.
+        [Parameter(Mandatory)]
+        [Object] $Session,
 
-        [Parameter(Mandatory=$true)]
-        [string]
         # The name of the API to use. The should be everything after `/api/` in the method's URI.
-        $Name,
+        [Parameter(Mandatory)]
+        [String] $Name,
 
-        [Microsoft.PowerShell.Commands.WebRequestMethod]
         # The HTTP/web method to use. The default is `GET`.
-        $Method = [Microsoft.PowerShell.Commands.WebRequestMethod]::Get,
+        [Microsoft.PowerShell.Commands.WebRequestMethod] $Method =
+            [Microsoft.PowerShell.Commands.WebRequestMethod]::Get,
 
-        [Parameter(Mandatory=$true,ParameterSetName='BodyFromHashtable')]
-        [hashtable]
-        # That parameters to pass to the method. These are converted to JSON and sent to the API in the body of the request.
-        $Parameter,
+        # The parameters to pass to the method's endpoint. They are sent in the request body as URL-encoded, name/value
+        # pairs, e.g. `name1=value1&name2=value2`. To send them as a JSON object, use the `AsJson` switch.
+        [Parameter(Mandatory, ParameterSetName='BodyFromHashtable')]
+        [hashtable] $Parameter,
 
+        # Send the request body as JSON. Otherwise, the data is sent as name/value pairs.
         [Parameter(ParameterSetName='BodyFromHashtable')]
-        [Switch]
-        # Send the request as JSON. Otherwise, the data is sent as name/value pairs.
-        $AsJson,
+        [switch] $AsJson,
 
-        [Parameter(Mandatory=$true,ParameterSetName='CustomBody')]
-        [string]
         # The body to send.
-        $Body,
+        [Parameter(Mandatory, ParameterSetName='CustomBody')]
+        [String] $Body,
 
-        [string]
-        # The content type of the web request. 
+        # The content type of the web request.
         #
-        # By default, 
-        # 
-        # * if passing a value to the `Parameter` parameter, the content type is set to `application/x-www-form-urlencoded`
-        # * if passing a value to the `Parameter` parameter and you're using the `AsJson` switch, the content type is set to `application/json`.
-        # 
-        # Otherwise, the content type is not set. If you're passing your own body to the `Body` parameter, you may have to set the appropriate content type for BuildMaster to respond.
-        $ContentType
+        # By default,
+        #
+        # * if passing a value to the `Parameter` parameter, the content type is set to
+        # `application/x-www-form-urlencoded`
+        # * if passing a value to the `Parameter` parameter and you're using the `AsJson` switch, the content type is
+        # set to `application/json`.
+        #
+        # Otherwise, the content type is not set. If you're passing your own body to the `Body` parameter, you may have
+        # to set the appropriate content type for BuildMaster to respond.
+        [String] $ContentType
     )
 
     Set-StrictMode -Version 'Latest'
     Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
 
-    $uri = '{0}api/{1}' -f $Session.Uri,$Name
-    
+    $uri = '{0}api/{1}' -f $Session.Url,$Name
+
     $debugBody = ''
     $webRequestParam = @{ }
     if( $Body )
@@ -86,19 +90,36 @@ function Invoke-BMRestMethod
         }
         else
         {
-            $keyValues = $Parameter.Keys | ForEach-Object { '{0}={1}' -f [Web.HttpUtility]::UrlEncode($_),[Web.HttpUtility]::UrlEncode($Parameter[$_]) }
-            $Body = $keyValues -join '&'
+            $bodyBuilder = [Text.StringBuilder]::New()
+            $valueToMask = ''
+            foreach ($paramName in $Parameter.Keys)
+            {
+                $paramValue = $Parameter[$paramName]
+                if ($bodyBuilder.Length -gt 0)
+                {
+                    [void]$bodyBuilder.Append('&')
+                }
+                [void]$bodyBuilder.Append([Web.HttpUtility]::UrlEncode($paramName))
+                [void]$bodyBuilder.Append('=')
+                [void]$bodyBuilder.Append([Web.HttpUtility]::UrlEncode($paramValue))
+
+                if ($paramName -eq 'API_Key')
+                {
+                    $valueToMask = $paramValue
+                }
+            }
+            $Body = $bodyBuilder.ToString()
+            $debugBody = $Body
+            if ($valueToMask)
+            {
+                $debugBody = $debugBody -replace [regex]::Escape($valueToMask), '********'
+
+            }
+
             if( -not $ContentType )
             {
                 $ContentType = 'application/x-www-form-urlencoded; charset=utf-8'
             }
-            $debugBody = $Parameter.Keys | ForEach-Object {
-                $value = $Parameter[$_]
-                if( $_ -eq 'API_Key' )
-                {
-                    $value = '********'
-                }
-                '    {0}={1}' -f $_,$value }
         }
         $webRequestParam['Body'] = $Body
     }
@@ -116,7 +137,7 @@ function Invoke-BMRestMethod
     Write-Debug -Message ('{0} {1}' -f $Method.ToString().ToUpperInvariant(),($uri -replace '\b(API_Key=)([^&]+)','$1********'))
     if( $ContentType )
     {
-        Write-Debug -Message ('    Content-Type: {0}' -f $ContentType)
+        Write-Debug -Message ('Content-Type: {0}' -f $ContentType)
     }
     foreach( $headerName in $headers.Keys )
     {
@@ -126,35 +147,26 @@ function Invoke-BMRestMethod
             $value = '*' * 8
         }
 
-        Write-Debug -Message ('    {0}: {1}' -f $headerName,$value)
+        Write-Debug -Message ('{0}: {1}' -f $headerName,$value)
     }
-    
-    $debugBody | Write-Debug
-    
-    $numErrors = $Global:Error.Count
+
+    if ($debugBody)
+    {
+        ($debugBody -split ([regex]::Escape([Environment]::NewLine))) | Write-Debug
+    }
+
     try
     {
         if( $Method -eq [Microsoft.PowerShell.Commands.WebRequestMethod]::Get -or $PSCmdlet.ShouldProcess($Uri,$Method) )
         {
-            Invoke-RestMethod -Method $Method -Uri $uri @webRequestParam -Headers $headers | 
-                ForEach-Object { $_ } 
+            Invoke-RestMethod -Method $Method -Uri $uri @webRequestParam -Headers $headers |
+                ForEach-Object { $_ } |
+                Where-Object { $_ }
         }
     }
     catch
     {
-        $webExceptions = @( 'Microsoft.PowerShell.Commands.HttpResponseException', 'System.Net.WebException' )
-        if( $_.Exception.GetType().FullName -notin $webExceptions )
-        {
-            throw
-        }
-
-        if( $ErrorActionPreference -eq 'Ignore' )
-        {
-            for( $idx = $numErrors; $idx -lt $Global:Error.Count; ++$idx )
-            {
-                $Global:Error.RemoveAt(0)
-            }
-        }
+        $Global:Error.RemoveAt(0)
         Write-Error -ErrorRecord $_ -ErrorAction $ErrorActionPreference
     }
 }

--- a/BuildMasterAutomation/Functions/Invoke-BMRestMethod.ps1
+++ b/BuildMasterAutomation/Functions/Invoke-BMRestMethod.ps1
@@ -66,9 +66,9 @@ function Invoke-BMRestMethod
 
     $debugBody = ''
     $webRequestParam = @{ }
-    if( $Body )
+    if ($Body)
     {
-        $webRequestParam['Body'] = $Body
+        $webRequestParam['Body'] = $debugBody = $Body
     }
     elseif( $Parameter )
     {

--- a/BuildMasterAutomation/Functions/New-BMBuild.ps1
+++ b/BuildMasterAutomation/Functions/New-BMBuild.ps1
@@ -1,17 +1,21 @@
 
-function New-BMPackage
+function New-BMBuild
 {
     <#
     .SYNOPSIS
-    Creates a new package for a release.
+    Creates a new build for a release.
 
     .DESCRIPTION
-    The `New-BMPackage` creates a new package/version/build of an application. In order to deploy an application, the application must have a release. Then you create packages in that release, and each package is then deployed using the release's pipeline.
+    The `New-BMBuild` creates a new version/build of an application. In order to deploy an application, the application
+    must have a release. Then you create builds in that release, and each build is then deployed using the release's
+    pipeline.
 
     .EXAMPLE
-    New-BMPackage -Session $session -Release $release
+    New-BMBuild -Session $session -Release $release
 
-    Demonstrates how to create a new package in the `$release` release. BuildMaster detects what application based on the release (since releases are always tied to applications). Verion numbers and package numbers are incremented and handled based on the release settings.
+    Demonstrates how to create a new build in the `$release` release. BuildMaster detects what application based on the
+    release (since releases are always tied to applications). Verion numbers and build numbers are incremented and
+    handled based on the release settings.
 
     The `$release` parameter can be:
 
@@ -19,58 +23,57 @@ function New-BMPackage
     * A release ID integer.
 
     .EXAMPLE
-    New-BMPackage -Session $session -ReleaseName '53' -Application $applicatoin
+    New-BMBuild -Session $session -ReleaseName '53' -Application $applicatoin
 
-    Demonstrates how to create a new package by using the release's name. Since release names are only unique within an application, you must also specify the application via the `Application` parameter.
+    Demonstrates how to create a new build by using the release's name. Since release names are only unique within an
+    application, you must also specify the application via the `Application` parameter.
 
     .EXAMPLE
-    New-BMPackage -Session $session -Release $release -PacakgeName '56.develop' -Variable @{ ProGetPackageName = '17.1.54+developer.deadbee' }
+    New-BMBuild -Session $session -Release $release -PacakgeName '56.develop' -Variable @{ ProGetPackageName = '17.1.54+developer.deadbee' }
 
-    Demonstrates how to create a release with a specific name, `56.develop`, and with a package-level variable, `ProGetPackageName`.
+    Demonstrates how to create a release with a specific name, `56.develop`, and with a build-level variable,
+    `ProGetPackageName`.
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [object]
-        # An object that represents the instance of BuildMaster to connect to. Use the `New-BMSession` function to creates a session object.
-        $Session,
+        # An object that represents the instance of BuildMaster to connect to. Use the `New-BMSession` function to
+        # creates a session object.
+        [Parameter(Mandatory)]
+        [Object] $Session,
 
-        [Parameter(Mandatory=$true,ParameterSetName='ByReleaseID')]
-        [object]
-        # The release where the package should be created. Can be:
+        # The release where the build should be created. Can be:
         #
-        # * a release object with an `id` property 
+        # * a release object with an `id` property
         # * the release ID as an integer
-        $Release,
+        [Parameter(Mandatory, ParameterSetName='ByReleaseID')]
+        [Object] $Release,
 
-        [Parameter(Mandatory=$true,ParameterSetName='ByReleaseNumber')]
-        [string]
-        # The release number where the package should be created. Release numbers are unique within an application and can be duplicated between applications. If you use this parameter to identify the release, you must also provide a value for the `Application` parameter.
-        $ReleaseNumber,
+        # The release number where the build should be created. Release numbers are unique within an application and
+        # can be duplicated between applications. If you use this parameter to identify the release, you must also
+        # provide a value for the `Application` parameter.
+        [Parameter(Mandatory, ParameterSetName='ByReleaseNumber')]
+        [String] $ReleaseNumber,
 
-        [Parameter(Mandatory=$true,ParameterSetName='ByReleaseNumber')]
-        [object]
         # The application where the release identified by the `ReleaseNumber` parameter can be found. Can be:
         #
         # * An application object with a `Application_Id`, `id`, `Application_Name`, or `name` properties.
         # * The application ID as an integer.
         # * The application name as a string.
-        $Application,
+        [Parameter(Mandatory, ParameterSetName='ByReleaseNumber')]
+        [Object] $Application,
 
-        [string]
-        # The package number/name. If not provided, BuildMaster generates one based on the release settings.
-        $PackageNumber,
+        # The build number/name. If not provided, BuildMaster generates one based on the release settings.
+        [string] $BuildNumber,
 
-        [hashtable]
-        # Any package variables to set. Package variables are unique to each package.
-        $Variable
+        # Any build variables to set. Build variables are unique to each build.
+        [hashtable] $Variable
     )
 
     Set-StrictMode -Version 'Latest'
     Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
 
-    $parameters = @{ } 
-    
+    $parameters = @{ }
+
     if( $PSCmdlet.ParameterSetName -eq 'ByReleaseID' )
     {
         $parameters | Add-BMObjectParameter -Name 'release' -Value $Release
@@ -81,9 +84,9 @@ function New-BMPackage
         $parameters | Add-BMObjectParameter -Name 'application' -Value $Application
     }
 
-    if( $PackageNumber )
+    if( $BuildNumber )
     {
-        $parameters['packageNumber'] = $PackageNumber
+        $parameters['buildNumber'] = $BuildNumber
     }
 
     if( $Variable )
@@ -94,5 +97,5 @@ function New-BMPackage
         }
     }
 
-    Invoke-BMRestMethod -Session $Session -Name 'releases/packages/create' -Parameter $parameters -Method Post
+    Invoke-BMRestMethod -Session $Session -Name 'releases/builds/create' -Parameter $parameters -Method Post
 }

--- a/BuildMasterAutomation/Functions/New-BMPackage.ps1
+++ b/BuildMasterAutomation/Functions/New-BMPackage.ps1
@@ -1,0 +1,52 @@
+
+function New-BMPackage
+{
+    <#
+    .SYNOPSIS
+    Obsolete. Use "New-BMBuild" instead.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [Object] $Session,
+
+        [Parameter(Mandatory, ParameterSetName='ByReleaseID')]
+        [Object] $Release,
+
+        [Parameter(Mandatory, ParameterSetName='ByReleaseNumber')]
+        [String] $ReleaseNumber,
+
+        [Parameter(Mandatory, ParameterSetName='ByReleaseNumber')]
+        [Object] $Application,
+
+        [string] $PackageNumber,
+
+        [hashtable] $Variable
+    )
+
+    Set-StrictMode -Version 'Latest'
+    Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+
+    $msg = 'The BuildMasterAutomation module''s ""Get-BMPackage"" function is obsolete and will be removed in a ' +
+           'future version of BuildMasterAutomation. Use the "Get-BMBuild" function instead.'
+    Write-WarningOnce $msg
+
+    $newArgs = @{}
+    foreach ($paramName in @('Release', 'ReleaseNumber', 'Application', 'PackageNumber', 'Variable'))
+    {
+        if (-not $PSBoundParameters.ContainsKey($paramName))
+        {
+            continue
+        }
+
+        $newParamName = $paramName
+        if ($paramName -eq 'PackageNumber')
+        {
+            $newParamName = 'BuildNumber'
+        }
+
+        $newArgs[$newParamName] = $PSBoundParameters[$paramName]
+    }
+
+    New-BMBuild -Session $Session @newArgs
+}

--- a/BuildMasterAutomation/Functions/New-BMPipelinePostDeploymentOptionsObject.ps1
+++ b/BuildMasterAutomation/Functions/New-BMPipelinePostDeploymentOptionsObject.ps1
@@ -1,0 +1,57 @@
+
+function New-BMPipelinePostDeploymentOptionsObject
+{
+    <#
+    .SYNOPSIS
+    Creates an object to pass to `Set-BMPipeline` to set a pipeline's post-deployment options.
+
+    .DESCRIPTION
+    The `New-BMPipelinePostDeploymentOptionsObject` creates an object representing the post-deployment options for a
+    pipeline. The object returned should be passed to the `Set-BMPipeline` function's `-PostDeploymentOption` parameter.
+
+    If you don't pass any arguments, the post-deployment options object will have no properties. We don't know what the
+    behavior of `Set-BMPipeline` will be in the case. We assume it will remove explicitly set values, reverting them to
+    their defaults.
+
+    .EXAMPLE
+    New-BMPipelinePostDeploymentOptionsObject -CancelEarlierRelease $true -CreateNewRelease $true -DeployRelease $false
+
+    Demonstrates how to create a post-deployment options object that sets the options to the opposite of BuildMaster's
+    defaults.
+
+    .EXAMPLE
+    New-BMPipelinePostDeploymentOptionsObject -MarkDeployed $false
+
+    Demonstrates how to turn off a single option.
+    #>
+    [CmdletBinding()]
+    param(
+        [bool] $CancelEarlierReleases,
+
+        [bool] $CreateNewRelease,
+
+        [bool] $MarkDeployed
+    )
+
+    Set-StrictMode -Version 'Latest'
+    Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+
+    $options = @{ }
+
+    if ($PSBoundParameters.ContainsKey('CancelEarlierReleases'))
+    {
+        $options['CancelReleases'] = $CancelEarlierReleases
+    }
+
+    if ($PSBoundParameters.ContainsKey('CreateNewRelease'))
+    {
+        $options['CreateRelease'] = $CreateNewRelease
+    }
+
+    if ($PSBoundParameters.ContainsKey('MarkDeployed'))
+    {
+        $options['DeployRelease'] = $MarkDeployed
+    }
+
+    return [pscustomobject]$options
+}

--- a/BuildMasterAutomation/Functions/New-BMPipelineStageObject.ps1
+++ b/BuildMasterAutomation/Functions/New-BMPipelineStageObject.ps1
@@ -1,0 +1,61 @@
+
+function New-BMPipelineStageObject
+{
+    <#
+    .SYNOPSIS
+    Creates a pipeline stage object that can be passed to `Set-BMPipeline`.
+
+    .DESCRIPTION
+    The `New-BMPipelineStageObject` creates an object that represents a stage of a pipeline. The object returned can be
+    passed to the `Set-BMPipeline` function's `Stage` parameter. Pass the name of the stage to the `Name` parameter, the
+    description to the `Description` parameter, and the stage targets to the `Target` parameter. Target objects can be
+    created with the `New-BMPipelineStageTargetObject` function.
+
+    .EXAMPLE
+    New-BMPipelineStageObject -Name 'Example'
+
+    Demonstrates how to create a stage object with just a name.
+    #>
+    [CmdletBinding()]
+    param(
+        # The stage's name.
+        [Parameter(Mandatory)]
+        [String] $Name,
+
+        # The stage's description.
+        [String] $Description,
+
+        # A list of target objects for the stage. Target objects can be created with the
+        # `New-BMPipelineStageTargetObject` function.
+        [Parameter(ValueFromPipeline)]
+        [Object[]] $Target
+    )
+
+    begin
+    {
+        Set-StrictMode -Version 'Latest'
+        Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+
+        $stage = [pscustomobject]@{
+            Name = $Name;
+            Description = $Description;
+            Targets = $null;
+        }
+
+        $targets = [Collections.ArrayList]::New()
+    }
+
+    process
+    {
+        foreach( $item in $Target )
+        {
+            [void]$targets.Add($item)
+        }
+    }
+
+    end
+    {
+        $stage.Targets = $targets.ToArray()
+        return $stage
+    }
+}

--- a/BuildMasterAutomation/Functions/New-BMPipelineStageTargetObject.ps1
+++ b/BuildMasterAutomation/Functions/New-BMPipelineStageTargetObject.ps1
@@ -1,0 +1,110 @@
+
+function New-BMPipelineStageTargetObject
+{
+    <#
+    .SYNOPSIS
+    Creates a stage target object that can be passed to the `New-BMPipelineStageObject` function.
+
+    .DESCRIPTION
+    The `New-BMPipelineStageTargetObject` function creates a pipeline stage target object. Pass the plan name to execute
+    to the `PlanName` parameter. By default, creates an object that targets no servers.
+
+    To target servers in a specific environment, pass the environment's name to the `EnvironmentName` parameter.
+
+    To target all servers in an environment, use the `AllServers` switch. You must also pass an environment name.
+
+    To target servers in specific roles, pass the role name(s) to the `ServerRoleName`.
+
+    To target servers in specific server pools, pass the server pool names(s) to the `ServerPoolName` parameter.
+
+    To target specific servers, pass the server name(s) to the `ServerName` parameter.
+
+    .EXAMPLE
+    New-BMPipelineStageTargetObject -PlanName 'Deploy'
+
+    Demonstrates how to create a target object that executes a plan against no servers.
+
+    .EXAMPLE
+    New-BMPipelineStageTargetObject -PlanName 'Deploy' -EnvironmentName 'Integration'
+
+    Demonstrates how to create a target object that executes a plan against servers in a specific environment. In this
+    case, the `Integration` environment.
+
+    .EXAMPLE
+    New-BMPipelineStageTargetObject -PlanName 'Deploy' -EnvironmentName 'Integration' -ServerRoleName 'Build'
+
+    Demonstrates how to create a target object that executes a plan against servers with a specific role. In this case,
+    all servers with the `Build` role in the `Integration` environment will be targeted.
+
+    .EXAMPLE
+    New-BMPipelineStageTargetObject -PlanName 'Deploy' -EnvironmentName 'Integration' -ServerPoolName 'Build'
+
+    Demonstrates how to create a target object that executes a plan against servers in a specific pool. In this case,
+    all servers in the `Build` pool in the `Integration` environment will be targeted.
+
+    .EXAMPLE
+    New-BMPipelineStageTargetObject -PlanName 'Deploy' -EnvironmentName 'Integration' -AllServers
+
+    Demonstrates how to create a target object that executes a plan against all servers in a specific environment. In
+    this case, all servers in the `Integration` environment will be targeted.
+
+    .EXAMPLE
+    New-BMPipelineStageTargetObject -PlanName 'Deploy' -ServerName 'example.com'
+
+    Demonstrates how to create a target object that executes a plan against a specific server. In this case, only the
+    `example.com` server will be targed.
+    #>
+    [CmdletBinding(DefaultParameterSetName=0)]
+    param(
+        [Parameter(Mandatory)]
+        [String] $PlanName,
+
+        [Parameter(ParameterSetName=0)]
+        [Parameter(ParameterSetName=1)]
+        [Parameter(Mandatory, ParameterSetName=2)]
+        [Parameter(ParameterSetName=3)]
+        [Parameter(ParameterSetName=4)]
+        [String] $EnvironmentName,
+
+        [Parameter(Mandatory, ParameterSetName=1)]
+        [String[]] $ServerName,
+
+        [Parameter(Mandatory, ParameterSetName=2)]
+        [switch] $AllServers,
+
+        [Parameter(Mandatory, ParameterSetName=3)]
+        [String[]] $ServerRoleName,
+
+        [Parameter(Mandatory, ParameterSetName=4)]
+        [String[]] $ServerPoolName
+    )
+
+    Set-StrictMode -Version 'Latest'
+    Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+
+    $target = [pscustomobject]@{
+        PlanName = $PlanName;
+        EnvironmentName = $EnvironmentName;
+        ServerNames = @();
+        ServerRoleNames = @();
+    }
+
+    if( $PSCmdlet.ParameterSetName -ne 0 )
+    {
+        if( $PSCmdlet.ParameterSetName -eq 1 )
+        {
+            $target.ServerNames = $ServerName
+        }
+        elseif( $PSCmdlet.ParameterSetName -eq 3 )
+        {
+            $target.ServerRoleNames = $ServerRoleName
+        }
+        elseif( $PSCmdlet.ParameterSetName -eq 4 )
+        {
+            $target.ServerRoleNames = $ServerPoolName
+        }
+        $target | Add-Member -Name 'DefaultServerContext' -Value $PSCmdlet.ParameterSetName -MemberType NoteProperty
+    }
+
+    return $target
+}

--- a/BuildMasterAutomation/Functions/New-BMRelease.ps1
+++ b/BuildMasterAutomation/Functions/New-BMRelease.ps1
@@ -6,22 +6,26 @@ function New-BMRelease
     Creates a new release for an application in BuildMaster.
 
     .DESCRIPTION
-    The `New-BMRelease` function creates a release for an application in BuildMaster. It uses the BuildMaster [Release and Package Deployment API](http://inedo.com/support/documentation/buildmaster/reference/api/release-and-package).
+    The `New-BMRelease` function creates a release for an application in BuildMaster. It uses the BuildMaster
+    [Release and Build Deployment API](https://docs.inedo.com/docs/buildmaster-reference-api-release-and-build).
 
     .EXAMPLE
     New-BMRelease -Session $session -Application 'BuildMasterAutomation' -Number '1.0' -Pipeline 'PowerShellModule'
 
-    Demonstrates how to create a release using application/pipeline names. In this example, creates a `1.0` release for the `BuildMasterAutomation` application using the `PowerShellModule` pipeline.
+    Demonstrates how to create a release using application/pipeline names. In this example, creates a `1.0` release for
+    the `BuildMasterAutomation` application using the `PowerShellModule` pipeline.
 
     .EXAMPLE
-    New-BMRelease -Session $session -Application 25 -Number '2.0' -Pipeline 3
+    New-BMRelease -Session $session -Application 25 -Number '2.0' -Pipeline 'Deploy'
 
-    Demonstrates how to create a release using application/pipeline IDs. In this example, creates a `1.0` release for the application whose ID is `25` using the pipeline whose ID is `3`.
+    Demonstrates how to create a release using an application id and pipeline name.. In this example, creates a `2.0`
+    release for the application whose ID is `25` using the pipeline whose name is `Deploy`.
 
     .EXAMPLE
     New-BMRelease -Session $session -Application $app -Number '3.0' -Pipeline $pipeline
 
-    Demonstrates how to create a release using application/pipeline objects. In this example, creates a `1.0` release for the application represented by the `$app` object (which must have either a `Application_Id` or `Application_Name` property that represent the ID and name of the application, respectively) using the pipeline represented by the `$pipeline` object (which must have either a `Pipeline_Id` or `Pipeline_Name` property that represent the ID and name of the pipeline, respectively).
+    Demonstrates how to create a release using application and pipeline objects. In this example, creates a `3.0`
+    release for the application `$app` using the pipeline `$pipeline`.
 
     .EXAMPLE
     New-BMRelease -Session $session -Name 'BMA 1.0' -Application 'BuildMasterAutomation' -Number '1.0' -Pipeline 'PowerShellModule'
@@ -30,37 +34,24 @@ function New-BMRelease
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [object]
-        # An object that represents what BuildMaster instance to connect to and what API key to use. Use `New-BMSession` to create a session object.
-        $Session,
+        # The session to BuildMaster. Use `New-BMSession` to create a session object.
+        [Parameter(Mandatory)]
+        [Object] $Session,
 
-        [Parameter(Mandatory=$true,ValueFromPipeline=$true)]
-        [object]
-        # The application where the release should be created. Can be:
-        #
-        # * The application's name.
-        # * The application's ID.
-        # * An application object with either an `Application_Id` or `Application_Name` property that represent the application's ID and name, respectively.
-        $Application,
+        # The application where the release should be created. Pass an application id, name, or object.
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [Object] $Application,
 
-        [Parameter(Mandatory=$true)]
-        [string]
         # The release number, e.g. 1, 2, 3, 1.0, 2.0, etc.
-        $Number,
+        [Parameter(Mandatory)]
+        [String] $Number,
 
-        [Parameter(Mandatory=$true)]
-        [object]
-        # The pipeline the release should use. Can be:
-        #
-        # * The pipeline's name.
-        # * The pipeline's ID.
-        # * A pipeline object with either a `Pipeline_Id` or `Pipeline_Name` property that represent the pipeline's ID and name, respectively.
-        $Pipeline,
+        # The pipeline the release should use. Pass a pipeline name or object.
+        [Object] $Pipeline,
 
-        [string]
-        # The name of the release. By default, BuildMaster uses the release number, passed with the `Number` parameter.
-        $Name
+        # The name of the release. By default, BuildMaster uses the release number, i.e. the value of the `Number`
+        # parameter.
+        [String] $Name
     )
 
     process
@@ -72,10 +63,11 @@ function New-BMRelease
                             releaseNumber = $Number;
                             releaseName = $Name;
                        }
-        
-        $parameters | 
-            Add-BMObjectParameter -Name 'application' -Value $Application -PassThru | 
-            Add-BMObjectParameter -Name 'pipeline' -Value $Pipeline
+
+        $parameters |
+            Add-BMObjectParameter -Name 'application' -Value $Application -PassThru |
+            Add-BMObjectParameter -Name 'RaftItem' -Value $Pipeline -PassThru |
+            Add-BMObjectParameter -Name 'pipeline' -Value $Pipeline -AsName
 
         Invoke-BMRestMethod -Session $Session -Name 'releases/create' -Method Post -Parameter $parameters
     }

--- a/BuildMasterAutomation/Functions/New-BMSession.ps1
+++ b/BuildMasterAutomation/Functions/New-BMSession.ps1
@@ -6,31 +6,35 @@ function New-BMSession
     Creates a session object used to communicate with a BuildMaster instance.
 
     .DESCRIPTION
-    The `New-BMSession` function creates and returns a session object that is required when calling any function in the BuildMasterAutomation module that communicates with BuildMaster. The session includes BuildMaster's URI and the credentials to use when making using BuildMaster's API.
+    The `New-BMSession` function creates and returns a session object that is required by any function in the
+    BuildMasterAutomation module that communicates with BuildMaster. The session includes BuildMaster's URL and the
+    credentials to use when making requests to BuildMaster's APIs
 
     .EXAMPLE
-    $session = New-BMSession -Uri 'https://buildmaster.com' -Credential $credential
+    $session = New-BMSession -Url 'https://buildmaster.com' -Credential $credential
 
-    Demonstrates how to call `New-BMSession`. In this case, the returned session object can be passed to other BuildMasterAutomation module function to communicate with BuildMaster at `https://buildmaster.com` with the credential in `$credential`.
+    Demonstrates how to call `New-BMSession`. In this case, the returned session object can be passed to other
+    BuildMasterAutomation module functions to communicate with BuildMaster at `https://buildmaster.com` with the
+    credential in `$credential`.
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [uri]
         # The URI to the BuildMaster instance to use.
-        $Uri,
+        [Parameter(Mandatory)]
+        [Alias('Uri')]
+        [Uri] $Url,
 
-        [Parameter(Mandatory=$true)]
-        [string]
         # The API key to use when making requests to BuildMaster.
-        $ApiKey
+        [Parameter(Mandatory)]
+        [String] $ApiKey
     )
 
     Set-StrictMode -Version 'Latest'
     Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
 
     return [pscustomobject]@{
-                                Uri = $Uri;
-                                ApiKey = $ApiKey;
-                            }
+            Url = $Url;
+            ApiKey = $ApiKey;
+        } |
+        Add-Member -Name 'Uri' -MemberType AliasProperty -Value 'Url' -PassThru
 }

--- a/BuildMasterAutomation/Functions/Publish-BMReleaseBuild.ps1
+++ b/BuildMasterAutomation/Functions/Publish-BMReleaseBuild.ps1
@@ -1,61 +1,60 @@
 
-function Publish-BMReleasePackage
+function Publish-BMReleaseBuild
 {
     <#
     .SYNOPSIS
-    Deploys a release package in BuildMaster.
+    Deploys a release build in BuildMaster.
 
     .DESCRIPTION
-    The `Publish-BMReleasePackage` deploys a release package in BuildMaster. The package is deployed using the pipeline assigned to the release the package is part of. This function uses BuildMaster's [Release and Package Deployment API](http://inedo.com/support/documentation/buildmaster/reference/api/release-and-package).
+    The `Publish-BMReleaseBuild` deploys a release build in BuildMaster. The build is deployed using the pipeline
+    assigned to the release the build is part of. This function uses BuildMaster's
+    [Release and Build Deployment API](http://inedo.com/support/documentation/buildmaster/reference/api/release-and-build).
 
-    Pass the package to deploy to the `Package` parameter. This can be a package object or a package ID (as an integer).
+    Pass the build to deploy to the `Build` parameter. This can be a build object or a build ID (as an integer).
 
-    To deploy a package, it must be part of a release that has a pipeline. That pipeline must have at least one stage and that stage must have a plan. If none of these conditions are met, you'll get no object back with no errors written.
-
-    .EXAMPLE
-    Publish-BMReleasePackage -Session $session -Package $package
-
-    Demonstrates how to deploy a package by passing a package object to the `Package` parameter. This object must have an `id` or `pipeline_id` property.
-    
-    .EXAMPLE
-    Publish-BMReleasePackage -Session $session -Package 383
-
-    Demonstrates how to deploy a package by passing its ID to the `Package` parameter.
+    To deploy a build, it must be part of a release that has a pipeline. That pipeline must have at least one stage and
+    that stage must have a plan. If none of these conditions are met, you'll get no object back with no errors written.
 
     .EXAMPLE
-    Publish-BMReleasePackage -Session $session -Package $package -Stage $stage
+    Publish-BMReleaseBuild -Session $session -Build $build
 
-    Demonstrates how to deploy a package to a specific stage of the release pipeline. By default, a package will deploy to the first stage of the assigned pipeline.
+    Demonstrates how to deploy a build by passing a build object to the `Build` parameter. This object must have an `id`
+    or `pipeline_id` property.
+
+    .EXAMPLE
+    Publish-BMReleaseBuild -Session $session -Build 383
+
+    Demonstrates how to deploy a build by passing its ID to the `Build` parameter.
+
+    .EXAMPLE
+    Publish-BMReleaseBuild -Session $session -Build $build -Stage $stage
+
+    Demonstrates how to deploy a build to a specific stage of the release pipeline. By default, a build will deploy to
+    the first stage of the assigned pipeline.
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [object]
-        # An object representing the BuildMaster instance to connect to. Use the `New-BMSession` function to create a session object.
-        $Session,
+        # The session to BuildMaster. Use the `New-BMSession` function to create a session.
+        [Parameter(Mandatory)]
+        [Object] $Session,
 
-        [Parameter(Mandatory=$true)]
-        [object]
-        # The package to deploy. Can be:
-        #
-        # * A package object which has an `id` property.
-        # * The package's ID, as an integer.
-        $Package,
-        
-        [string]
-        # The name of the pipeline stage where the package will be deployed.
-        $Stage,
+        # The build to deploy. Can be a build id or object.
+        [Parameter(Mandatory)]
+        [Object] $Build,
 
-        [Switch]
-        # Instructs BuildMaster to run the deploy even if the deploy to previous stages failed.
-        $Force
+        # The name of the pipeline stage where the build will be deployed.
+        [String] $Stage,
+
+        # Instructs BuildMaster to run the deploy even if the deploy to previous stages failed or the stage isn't the
+        # first stage.
+        [switch] $Force
     )
 
     Set-StrictMode -Version 'Latest'
     Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
 
-    $parameters = @{} | Add-BMObjectParameter -Name 'package' -Value $Package -PassThru
-    
+    $parameters = @{} | Add-BMObjectParameter -Name 'build' -Value $Build -PassThru
+
     if( $Stage )
     {
         $parameters['toStage'] = $Stage
@@ -65,6 +64,6 @@ function Publish-BMReleasePackage
     {
         $parameters['force'] = 'true'
     }
-    
-    Invoke-BMRestMethod -Session $Session -Name 'releases/packages/deploy' -Parameter $parameters -Method Post
+
+    Invoke-BMRestMethod -Session $Session -Name 'releases/builds/deploy' -Parameter $parameters -Method Post
 }

--- a/BuildMasterAutomation/Functions/Publish-BMReleasePackage.ps1
+++ b/BuildMasterAutomation/Functions/Publish-BMReleasePackage.ps1
@@ -1,0 +1,40 @@
+
+function Publish-BMReleasePackage
+{
+    <#
+    .SYNOPSIS
+    Obsolete. Use "Publish-BMReleaseBuild" instead.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [Object] $Session,
+
+        [Parameter(Mandatory)]
+        [Object] $Package,
+
+        [String] $Stage,
+
+        [switch] $Force
+    )
+
+    Set-StrictMode -Version 'Latest'
+    Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+
+    $msg = 'The BuildMasterAutomation module''s ""Get-BMPackage"" function is obsolete and will be removed in a ' +
+           'future version of BuildMasterAutomation. Use the "Get-BMBuild" function instead.'
+    Write-WarningOnce $msg
+
+    $publishArgs = @{}
+    foreach ($paramName in @('Stage', 'Force'))
+    {
+        if (-not $PSBoundParameters.ContainsKey($paramName))
+        {
+            continue
+        }
+
+        $publishArgs[$newParamName] = $PSBoundParameters[$paramName]
+    }
+
+    Publish-BMReleaseBuild -Session $Session -Build $Package @publishArgs
+}

--- a/BuildMasterAutomation/Functions/Remove-BMApplication.ps1
+++ b/BuildMasterAutomation/Functions/Remove-BMApplication.ps1
@@ -1,0 +1,90 @@
+
+function Remove-BMApplication
+{
+    <#
+    .SYNOPSIS
+    Deletes applications in BuildMaster.
+
+    .DESCRIPTION
+    The `Remove-BMApplication` function removes an application from BuildMaster. Pass the application's id, name, or
+    object to the `Application` parameter. If the application is disabled, it will be deleted. To delete the application
+    even if it's still enabled, use the `Force` (switch).
+
+    Use `Disable-BMApplication` to disable an application.
+
+    Uses the BuildMaster native API.
+
+    .EXAMPLE
+    Remove-BMApplication -Session $session -Application $app
+
+    Demonstrates how to delete an application by passing an application object to the `Application` parameter.
+
+    .EXAMPLE
+    Remove-BMApplication -Session $session -Application 432
+
+    Demonstrates how to delete an application by passing its id to the `Application` parameter.
+
+    .EXAMPLE
+    Remove-BMApplication -Session $session -Application 'So Long'
+
+    Demonstrates how to delete an application by passing its name to the `Application` parameter.
+
+    .EXAMPLE
+    $app,433,'So Long 2' | Remove-BMApplication -Session $session
+
+    Demonstrates that you can pipe application ids, names, and/or objects to `Remove-BMApplication`.
+
+    .EXAMPLE
+    Remove-BMApplication -Session $session -Application $app -Force
+
+    Demonstrates how to delete an application even if its still enabled by using the `Force` (switch).
+    #>
+    [CmdletBinding()]
+    param(
+        # The session to BuildMaster. Use `New-BMSession` to create a session.
+        [Parameter(Mandatory)]
+        [Object] $Session,
+
+        # The application's id, name, or object to delete. Accepts pipeline input.
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [Object] $Application,
+
+        # If set, will delete an active application.
+        [switch] $Force
+    )
+
+    process
+    {
+        Set-StrictMode -Version 'Latest'
+        Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+
+        $getDeleteParams =
+            @{ } | Add-BMObjectParameter -Name 'Application' -Value $Application -ForNativeApi -PassThru
+
+        $app = Invoke-BMNativeApiMethod -Session $Session `
+                                        -Name 'Applications_GetApplication' `
+                                        -Parameter $getDeleteParams `
+                                        -Method Post
+
+        if (-not $app)
+        {
+            $msg = "Cannot delete application ""$($Application | Get-BMObjectName)"" because it does not exist."
+            Write-Error -Message $msg -ErrorAction $ErrorActionPreference
+            return
+        }
+
+        if (-not $Force -and $app.Active_Indicator -eq 'Y')
+        {
+            $msg = "Application ""$($app.Application_Name)"" is active. Only inactive applications can be deleted. " +
+                   'Use the "Disable-BMApplication" function to disable the application, or use the -Force (switch) ' +
+                   'on this function to delete an active application.'
+            Write-Error -Message $msg -ErrorAction $ErrorActionPreference
+        }
+
+        Invoke-BMNativeApiMethod -Session $Session `
+                                 -Name 'Applications_PurgeApplicationData' `
+                                 -Parameter $getDeleteParams `
+                                 -Method Post |
+            Out-Null
+    }
+}

--- a/BuildMasterAutomation/Functions/Remove-BMPipeline.ps1
+++ b/BuildMasterAutomation/Functions/Remove-BMPipeline.ps1
@@ -1,0 +1,61 @@
+
+function Remove-BMPipeline
+{
+    <#
+    .SYNOPSIS
+    Removes a pipeline from BuildMaster.
+
+    .DESCRIPTION
+    The `Remove-BMPipeline` function removes a pipeline from BuildMaster. Pass the pipeline's name or object to the
+    `Pipeline` parameter (or pipe it into the function). The pipeline will be deleted, and its change history will be
+    preserved.
+
+    To also delete the pipeline's change history, use the `PurgeHistory` switch.
+
+    .EXAMPLE
+    Remove-BMPipeline -Session $session -Pipeline 'Tutorial'
+
+    Demonstrates how to delete a pipeline using its name.
+
+    .EXAMPLE
+    Remove-BMPipeline -Session $session -Pipeline $pipeline
+
+    Demonstrates how to delete a pipeline using a pipeline object.
+
+    .EXAMPLE
+    $pipeline, 'Tutorial' | Remove-BMPipeline -Session $session
+
+    Demonstrates that you can pipe pipeline names and objects into `Remove-BMPipeline`.
+
+    .EXAMPLE
+    Remove-BMPipeline -Session $session -Pipeline $pipeline -PurgeHistory
+
+    Demonstrates how to remove the pipeline's change history along with the pipeline by using the `PurgeHistory` switch.
+    #>
+    [CmdletBinding()]
+    param(
+        # The session to BuildMaster. Use `New-BMSession` to create a session.
+        [Parameter(Mandatory)]
+        [Object] $Session,
+
+        # The name or pipeline object of the pipeline to delete.
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [Object] $Pipeline,
+
+        # If set, deletes the pipeline's change history. The default behavior preserve's the change history.
+        [switch] $PurgeHistory
+    )
+
+    process
+    {
+        Set-StrictMode -Version 'Latest'
+        Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+
+        if (-not $Pipeline)
+        {
+            return
+        }
+
+        $Pipeline | Remove-BMRaftItem -Session $session -PurgeHistory:$PurgeHistory
+    }
+}

--- a/BuildMasterAutomation/Functions/Remove-BMRaftItem.ps1
+++ b/BuildMasterAutomation/Functions/Remove-BMRaftItem.ps1
@@ -1,0 +1,62 @@
+
+function Remove-BMRaftItem
+{
+    <#
+    .SYNOPSIS
+    Removes a raft item from BuildMaster.
+
+    .DESCRIPTION
+    The `Remove-BMRaftItem` function removes a raft item from BuildMaster. Pass the raft item's name or a raft item
+    object to the `RaftItem` parameter (or pipe them into the function). The raft item will be deleted, and its change
+    history will be preserved.
+
+    To also delete the raft item's change history, use the `PurgeHistory` switch.
+
+    .EXAMPLE
+    Remove-BMRaftItem -Session $session -RaftItem 'Tutorial'
+
+    Demonstrates how to delete a raft item using its name.
+
+    .EXAMPLE
+    Remove-BMRaftItem -Session $session -RaftItem $raftItem
+
+    Demonstrates how to delete a raft item using a raft item object.
+
+    .EXAMPLE
+    $raftItem, 'Tutorial' | Remove-BMRaftItem -Session $session
+
+    Demonstrates that you can pipe raft item names and objects into `Remove-BMRaftItem`.
+
+    .EXAMPLE
+    Remove-BMRaftItem -Session $session -RaftItem $raftItem -PurgeHistory
+
+    Demonstrates how to remove the raft item's change history along with the raft item by using the `PurgeHistory`
+    switch.
+    #>
+    [CmdletBinding()]
+    param(
+        # The session to BuildMaster. Use `New-BMSession` to create a session.
+        [Parameter(Mandatory)]
+        [Object] $Session,
+
+        # The name or or a raft item object of the raft item to delete.
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [Object] $RaftItem,
+
+        # If set, deletes the raft item's change history. The default behavior preserve's the change history.
+        [switch] $PurgeHistory
+    )
+
+    Set-StrictMode -Version 'Latest'
+    Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+
+    $raftParams = @{} |
+        Add-BMObjectParameter -Name 'RaftItem' -Value $RaftItem -ForNativeApi -PassThru |
+        Add-BMParameter -Name 'PurgeHistory_Indicator' -Value $PurgeHistory.IsPresent -PassThru
+
+    Invoke-BMNativeApiMethod -Session $Session `
+                             -Name 'Rafts_DeleteRaftItem' `
+                             -Parameter $raftParams `
+                             -Method Post |
+        Out-Null
+}

--- a/BuildMasterAutomation/Functions/Set-BMRaftItem.ps1
+++ b/BuildMasterAutomation/Functions/Set-BMRaftItem.ps1
@@ -1,0 +1,119 @@
+
+function Set-BMRaftItem
+{
+    <#
+    .SYNOPSIS
+    Creates or updates a raft item in BuildMaster.
+
+    .DESCRIPTION
+    The `Set-BMRaftItem` function creates or updates a raft item in BuildMaster. Pass the raft item's name to the
+    `Name` parameter. Pass the raft item's raft id or a raft object to the `Raft` parameter. Pass the object's
+    type to the `TypeCode` parameter. The raft item will be created if it doesn't exist, or updated if it does.
+
+    To assign the raft item to a specific application, pass the application's id, name or an application object to the
+    `Application` parameter.
+
+    Pass the raft item's content to the `Content` parameter.
+
+    Pass the username of the user creating/updating the raft item to the `UserName` parameter. The default username is
+    `DOMAIN\UserName` if the current computer is in a Microsoft domain, `UserName@MachineName` otherwise.
+
+    If you want the created/updated raft item's object to be returned, use the `PassThru` switch.
+
+    When creating scripts, the name of the raft item should end with an extension for the type of script it is, e.g.
+    `.ps1` for PowerShell scripts, `.sh` for shell scripts, etc.
+
+    Parameters not passed will not be sent to BuildMaster, and typically BuildMaster leaves those values as-is. Any
+    parameter that you pass will get sent to BuildMaster and the respective raft item properties will be updated.
+
+    .EXAMPLE
+    Set-BMRaftItem -Session $session -Raft $raft -TypeCode Pipeline -Name 'Pipeline'
+
+    Demonstrates how to use Set-BMRaftItem. In this example, an empty, global pipeline will be created in the raft
+    represented by the `$raft` object.
+
+    .EXAMPLE
+    Set-BMRaftItem -Session $session -Raft $raft -TypeCode Module -Name 'Module' -Application $app -Content $otterScript
+
+    Demonstrates how to use Set-BMRaftItem. In this example, a module will be created/updated for the application
+    represented by the `$app` object with the content in the `$otterScript` variable.
+    #>
+    [CmdletBinding()]
+    param(
+        # The session to BuildMaster. Use `New-BMSession` to create a session.
+        [Parameter(Mandatory)]
+        [Object] $Session,
+
+        # The raft where the raft item should be saved. Pass the raft id, name or a raft object.
+        [Parameter(Mandatory)]
+        [Object] $Raft,
+
+        # The type of the raft item. Valid values are:
+        #
+        # * Module (for creating OtterScript modules)
+        # * Script (for creating PowerShell, batch, or shell scripts; make sure the raft item's name ends with the
+        # extension for that script type)
+        # * DeploymentPlan (for creating a deployment plan)
+        # * Pipeline (for creating a pipeline; use `Set-BMPipeline` instead)
+        [Parameter(Mandatory)]
+        [BMRaftItemTypeCode] $TypeCode,
+
+        # The name of the raft item.
+        #
+        # If the raft item is a script, the name must end with the extension of the script type, e.g. `.ps1` for
+        # PowerShell scripts, `.sh` for shell scripts, etc.
+        [Parameter(Mandatory)]
+        [String] $Name,
+
+        # The application the raft item belongs to. Pass the application's id, name, or an application object.
+        [Object] $Application,
+
+        # The content of the raft item.
+        [String] $Content,
+
+        # The username of the individual who is creating/updating the raft item.
+        [String] $UserName,
+
+        # If set, will return an object representing the created/update raft item.
+        [switch] $PassThru
+    )
+
+    Set-StrictMode -Version 'Latest'
+    Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+
+    if( -not $UserName )
+    {
+        $UserName = [Environment]::UserName
+        if ([Environment]::UserDomainName)
+        {
+            $UserName = "$([Environment]::UserDomainName)\$($UserName)"
+        }
+        else
+        {
+            $UserName = "$($UserName)@$([Environment]::MachineName)"
+        }
+    }
+
+    $contentBytes = $Content | ConvertTo-BMNativeApiByteValue
+    $raftParams = @{
+            RaftItem_Name = $Name;
+            RaftItemType_Code = $TypeCode;
+            ModifiedOn_Date = [DateTimeOffset]::Now;
+            ModifiedBy_User_Name = $UserName;
+        } |
+        Add-BMObjectParameter -ForNativeApi -PassThru -Name 'Application' -Value $Application |
+        Add-BMObjectParameter -ForNativeApi -PassThru -Name 'Raft' -Value $Raft |
+        Add-BMParameter -PassThru -Name 'ModifiedBy_User_Name' -Value $UserName |
+        Add-BMParameter -PassThru -Name 'Content_Bytes' -Value $contentBytes
+
+    Invoke-BMNativeApiMethod -Session $Session `
+                             -Name 'Rafts_CreateOrUpdateRaftItem' `
+                             -Parameter $raftParams `
+                             -Method Post |
+        Out-Null
+
+    if ($PassThru)
+    {
+        Get-BMRaftItem -Session $Session -Raft $Raft -Name $Name -Application $Application -TypeCode $TypeCode
+    }
+}

--- a/BuildMasterAutomation/Functions/Set-BMRelease.ps1
+++ b/BuildMasterAutomation/Functions/Set-BMRelease.ps1
@@ -3,43 +3,37 @@ function Set-BMRelease
 {
     <#
     .SYNOPSIS
-    Updates a release's pipeline or name.
+    Updates a release in BuildMaster.
 
     .DESCRIPTION
-    The `Set-BMRelease` function updates a release's pipeline or name. To change a release's pipeline, pass the pipeline's ID to the `PipelineID` parameter. To change the pipeline's name, pass the new name to the `Name` parameter. 
-    
+    The `Set-BMRelease` function creates a BuildMaster release or updates an existing release. Pass the release's
+    pipeline name or a pipeline object to the `Pipeline` object. Pass the release's name to the `Name` parameter.
+
     This function uses the BuildMaster native API endpoint "Releases_CreateOrUpdateRelease".
 
-    Pass the release you want to update to the `Release` parameter. You may pass the release's ID (as an integer), the release's number, or a release object as returned by the `Get-BMRelease` function.
+    If any parameter isn't passed, and the release exists, the respective properties on the release won't be updated.
 
     .EXAMPLE
-    Set-BMRelease -Session $session -Release $release -PipelineID 45 -Name 'My New Name'
+    Set-BMRelease -Session $session -Release $release -Pipeline 'My Pipeline' -Name 'My New Name'
 
     Demonstrates how to update the pipeline and name of a release.
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [object]
-        # An object that represents what BuildMaster instance to connect to and what API key to use. Use `New-BMSession` to create a session object.
-        $Session,
+        # The session to BuildMaster. Use the `New-BMSession` object to create the session.
+        [Parameter(Mandatory)]
+        [Object] $Session,
 
-        [Parameter(Mandatory=$true,ParameterSetName='Update')]
-        [object]
-        # The release to update. Can be:
-        #
-        # * The release's number.
-        # * The release's ID.
-        # * An release object with either a `Release_Id` or `Release_Name` property that represent the application's ID and name, respectively.
-        $Release,
+        # The release to update. Pass the release's id, name, or a release object.
+        [Parameter(Mandatory, ParameterSetName='Update')]
+        [Object] $Release,
 
-        [int]
-        # The ID of the release's new pipeline.
-        $PipelineID,
+        # The release's pipeline.
+        [Alias('PipelineID')]
+        [Object] $Pipeline,
 
-        [string]
-        # The new name of the release.
-        $Name
+        # The release's name. If the release exists, its name will be changed to this value.
+        [String] $Name
     )
 
     process
@@ -54,9 +48,10 @@ function Set-BMRelease
             return
         }
 
-        if( -not $PipelineID )
+        $pipelineName = $bmRelease.pipelineName
+        if ($Pipeline)
         {
-            $PipelineID = $bmRelease.PipelineId
+            $pipelineName = $Pipeline.RaftItem_Name
         }
 
         if( -not $Name )
@@ -64,10 +59,10 @@ function Set-BMRelease
             $Name = $bmRelease.name
         }
 
-        $parameter = @{ 
+        $parameter = @{
                         Application_Id = $bmRelease.ApplicationId;
                         Release_Number = $bmRelease.number;
-                        Pipeline_Id = $PipelineID;
+                        Pipeline_Name = $pipelineName;
                         Release_Name = $Name;
                      }
         Invoke-BMNativeApiMethod -Session $Session -Name 'Releases_CreateOrUpdateRelease' -Method Post -Parameter $parameter | Out-Null

--- a/BuildMasterAutomation/Functions/Test-BMID.ps1
+++ b/BuildMasterAutomation/Functions/Test-BMID.ps1
@@ -1,0 +1,58 @@
+
+function Test-BMID
+{
+    <#
+    .SYNOPSIS
+    Tests if an object is a BuildMaster ID.
+
+    .DESCRIPTION
+    The `Test-BMID` function tests if an object is actually an ID. An ID is any signed or unsigned integer type,
+    including bytes.
+
+    .EXAMPLE
+    1 | Test-BMID
+
+    Returns `$true`.
+
+    .EXAMPLE
+    '1' | Test-BMID
+
+    Returns `$false`.
+
+    .EXAMPLE
+    $null | Test-BMID
+
+    Returns `$false`.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline, Position=0)]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [Object] $ID
+    )
+
+    process
+    {
+        Set-StrictMode -Version 'Latest'
+        Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+
+        if ($null -eq $ID)
+        {
+            return $false
+        }
+
+        $intTypes = @(
+            [TypeCode]::Byte,
+            [TypeCode]::Int16,
+            [TypeCode]::Int32,
+            [TypeCode]::Int64,
+            [TypeCode]::SByte,
+            [TypeCode]::UInt16,
+            [TypeCode]::UInt32,
+            [TypeCode]::UInt64
+        )
+
+        return ([Type]::GetTypeCode($ID.GetType()) -in $intTypes)
+    }
+}

--- a/BuildMasterAutomation/Functions/Test-BMName.ps1
+++ b/BuildMasterAutomation/Functions/Test-BMName.ps1
@@ -1,0 +1,46 @@
+
+function Test-BMName
+{
+    <#
+    .SYNOPSIS
+    Tests if an object is a BuildMaster name.
+
+    .DESCRIPTION
+    The `Test-BMName` function tests if an object is actually a name.
+
+    .EXAMPLE
+    1 | Test-BMName
+
+    Returns `$false`.
+
+    .EXAMPLE
+    'YOLO' | Test-BMName
+
+    Returns `$true`.
+
+    .EXAMPLE
+    '$null | Test-BMName
+
+    Returns `$false`.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline, Position=0)]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [Object] $Name
+    )
+
+    process
+    {
+        Set-StrictMode -Version 'Latest'
+        Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+
+        if ($null -eq $Name)
+        {
+            return $false
+        }
+
+        return ($Name -is [String])
+    }
+}

--- a/BuildMasterAutomation/Functions/Test-BMObject.ps1
+++ b/BuildMasterAutomation/Functions/Test-BMObject.ps1
@@ -1,0 +1,51 @@
+
+function Test-BMObject
+{
+    <#
+    .SYNOPSIS
+    Tests if an object is a BuildMaster object.
+
+    .DESCRIPTION
+    The `Test-BMObject` function tests if an object is actually a name.
+
+    .EXAMPLE
+    1 | Test-BMObject
+
+    Returns `$false`.
+
+    .EXAMPLE
+    'YOLO' | Test-BMObject
+
+    Returns `$false`.
+
+    .EXAMPLE
+    Get-BMApplication -Session $session -Name 'MyApp' | Test-BMObject
+
+    Returns `$true`.
+
+    .EXAMPLE
+    $null | Test-BMObject
+
+    Returns `$false`.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline, Position=0)]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [Object] $Object
+    )
+
+    process
+    {
+        Set-StrictMode -Version 'Latest'
+        Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+
+        if ($null -eq $Object)
+        {
+            return $false
+        }
+
+        return (-not ($Object | Test-BMID) -and -not ($Object | Test-BMName))
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ object returned.
 
 * `Invoke-BMRestMethod` (and by extension all the BuildMasterAutomation functions that call the API) no longer returns
 `$null`.
+* `Invoke-BMRestMethod` fails to log request body to the debug stream when using the `Body` parameter.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,124 @@
 # BuildMasterAutomation Changelog
 
+## 2.0.0
+
+### Upgrade Instructions
+
+***This release contains breaking changes. Please read these upgrade instructions carefully before upgrading.***
+
+This release adds support for BuildMaster 6.2.33, which contains breaking changes from version 6.1.
+
+* Remove usages of the `Get-BMDeployment` function's `Build`, `Release`, and `Application` parameters. The BuildMaster [Release and build deployment API](https://docs.inedo.com/docs/buildmaster-reference-api-release-and-build) no longer
+supports getting deploys for builds, releases, and applications.
+* Rename usages of the `Get-BMDeployment` function's `ID` parameter to `Deployment`.
+* Remove usages of the `New-BMApplication` function's `AllowMultipleActiveBuilds` switch. This functionality was
+removed from BuildMaster.
+* Rename usages of `New-BMPipeline` to `Set-BMPipeline`.
+* Update values passed to the `Set-BMPipeline` (née `New-BMPipeline`) function's `Stage` parameter. This parameter now
+requires an array of stage objects, which can be created with the new `New-BMPipelineStageObject` function.
+* Remove usages of the `Get-BMPipeline` function's `ID` parameter. BuildMaster pipelines no longer have ids, just
+names.
+* Update usages of the `Get-BMPipeline` function to pass a pipeline name to the `Name` parameter instead of an id.
+* Objects returned by `Get-BMPipeline` are now raft item objects. Check usages to ensure you're using correct
+properties.
+* Rename usages of the `New-BMPipeline` function to `Set-BMPipeline`.
+* `Set-BMPipeline` (née `New-BMPipeline`) now creates *or* updates a pipeline. Inspect usages to see the impact of this
+new behavior.
+* Update usages of the `Set-BMPipeline` (née `New-BMPipeline`) function's `Stage` parameter to pass stage objects
+instead of strings of XML. Use the new `New-BMPipelineStageObject` and `New-BMPipelineStageTargetObject` functions to
+create the objects you should pass.
+* Update usages of the `Set-BMPipeline` (née `New-BMPipeline`) function that use the return value. `Set-BMPipeline` no
+longer returns the pipeline object by default. Use the new `PassThru` switch and the pipeline object will be returned.
+* Add `-ErrorAction Ignore` to usages of `Remove-BMServer` and `Remove-BMServerRole` if you don't care if the item doesn't exist. `Remove-BMServer` and `Remove-BMServerRole` now write errors when the item to remove doesn't exist.
+* Update usages of `Set-BMRelease` to pass a pipeline name or pipeline object to the new `Pipeline` paramter and remove
+usages of the `PipelineID` parameter.
+
+### Added
+
+* Function `Add-BMParameter`, for adding values to a parameter hashtable (i.e. a hashtable that will be used as the body
+of a request to a BuildMaster API endpoint). If the value is `$null`, however, it won't be added.
+* Function `ConvertFrom-BMNativeApiByteValue` for converting `byte[]` values returned by the BuildMaster native API
+into their original strings.
+* Function `Get-BMObjectName` for getting the name of an object that was returned by the BuildMaster API.
+* Function `Get-BMBuild` for getting builds. It replaces the now obsolete `Get-BMPackage` function.
+* Parameter `Application` to the `Get-BMPipeline` function. It replaces the now obsolete parameter `ApplicationID`.
+* Function `Get-BMRaft` for getting all rafts.
+* Function `Get-BMRaftItem` for getting all raft items.
+* Parameter `Application` on the `New-BMApplication` function. It replaces the now obsolete parameter
+`ApplicationGroupID`.
+* Function `New-BMBuild` for creating builds. It replaces the now obsolete `New-BMPackage` function.
+* Function `New-BMPipelinePostDeploymentOptionsObject` for creating a post-deployment options object to use when
+creating a pipeline.
+* Function `New-BMPipelineStageObject` for creating a stage object that can be passed to the `Set-BMPipeline` function's
+`Stage` parameter.
+* Function `New-BMPipelineStageTargetObject` for creating a target object that can be passed to the
+`New-BMPipelineStageObject` function's `Target` parameter.
+* Parameter `Url` to the `New-BMSession` function. It replaces the now obsolete parameter `Uri` parameter.
+* Function `Publish-BMReleaseBuild`. It replaces the now obsolete `Publish-BMReleasePackage` function.
+* Function `Remove-BMApplication` function for deleting applications.
+* Function `Remove-BMPipeline` function for removing pipelines.
+* Function `Remove-BMRaftItem` function for deleting raft items.
+* Parameter `PostDeploymentOption` to the `Set-BMPipeline` (née `New-BMPipeline`) function for configuring a pipeline's
+post-deployment options. Use the `New-BMPipelinePostDeploymentOptionsObject` to create a post-deployment options object.
+* Parameter `EnforceStageSequence` to the `Set-BMPipeline` (née `New-BMPipeline`) function for controlling the
+pipeline's stage sequence enforcement.
+* Function `Set-BMRaftItem` for creating and/or updating a raft item.
+* Parameter `PassThru` to the `Set-BMPipeline` (née `New-BMPipeline`) for returning the created/updated pipeline object.
+* Parameter `Pipeline` to the `Set-BMRelease` function. This replaces the `PipelineID` parameter, which was removed.
+
+### Changed
+
+* The `Add-BMObjectParameter` function now accepts `$null` values. When passed a null value, it does nothing.
+* Renamed the `New-BMPipeline` function to `Set-BMPipeline` since the underlying API no longer has separate create and
+update endpoints, but a single create or update endpoint.
+* Renamed `Get-BMDeployment` function's `ID` parameter to `Deployment` and updated it to also accept deployment
+objects.
+* `Get-BMPipeline` function returns raft item objects instead of pipeline objects.
+* Renamed the `New-BMPackage` function's `PackageNumber` parameter to `BuildNumber`.
+* Renamed the `New-BMPipeline` function to `Set-BMPipeline` and updated it to create and/or update the pipeline.
+* The `Set-BMPipeline` (née `New-BMPipeline`) function's `Stage` parameter to take in stage objects instead of XML
+strings. Use the new `New-BMPipelineStageObject` and `New-BMPipelineStageTargetObject` functions to create the objects
+you should pass.
+* `Set-BMPipeline` (née `New-BMPipeline`) no longer returns the pipeline. Use the `PassThru` switch to have the pipeline
+object returned.
+* `Remove-BMServer` and `Remove-BMServerRole` now write an error when the item to delete doesn't exist. Use
+`-ErrorAction Ignore` to ignore if the item exists or not.
+
+### Deprecated
+
+#### Functions
+
+* The `Get-BMPackage` function. It is replaced by `Get-BMBuild`.
+* The `New-BMPackage` function. It is replaced by `New-BMBuild`.
+* The `Publish-BMReleasePackage` function. It is replaced by `Publish-BMReleaseBuild`.
+
+#### Function Parameters
+
+* The `Get-BMPipeline` function's `ApplicationID` parameter. Use the new `Application` parameter instead.
+* The `New-BMApplication` function's `ApplicationGroupID` parameter. Use the new `ApplicationGroup` parameter instead.
+* The `New-BMSession` function's `Uri` parameter. Use the new `Url` parameter instead.
+
+#### Object Properties
+
+* The `Uri` property on session objects. Use the new `Url` property instead.
+* The `Pipeline_Name` property on pipeline objects. Use the new `RaftItem_Name` property instead.
+* The `Pipeline_Id` property on pipeline objects. Use the new `RaftItem_Id` property instead.
+
+### Fixed
+
+* `Invoke-BMRestMethod` (and by extension all the BuildMasterAutomation functions that call the API) no longer returns
+`$null`.
+
+### Removed
+
+* `New-BMApplication` function's `AllowMultipleActiveBuilds` switch. Its functionality was removed from BuildMaster.
+* `Get-BMPipeline` function's `ID` parameter. Use the `Name` parameter instead. BuildMaster pipelines no longer have
+ids, just names.
+* Removed the `Get-BMDeployment` function's `Build`, `Release`, and `Application` parameters. The BuildMaster
+[Release and Build Deployment API](https://docs.inedo.com/docs/buildmaster-reference-api-release-and-build) no longer
+supports getting deploys for builds, releases, and applications.
+* Parameter `PipelineID` on the `Get-BMRelease` function. Use the new `Pipeline` parameter instead.
+
 ## 1.0.1
 
 2021-8-3

--- a/README.md
+++ b/README.md
@@ -9,66 +9,66 @@ With this module, you can:
  * Create and get applications
  * Create and get releases
  * Call BuildMaster's [native or other REST APIs](https://inedo.com/support/documentation/buildmaster/reference/api).
- 
+
 # Installation
- 
+
 To download, go to this project's [Github source code repository](https://github.com/pshdo/BuildMasterAutomation), click the green "Clone or Download" button, and choose "Download ZIP." Once the ZIP file is downloaded, right-click it and choose "Properties". On the Properties dialog box, click the "Unblock" button.
- 
-To install, open the downloaded ZIP file. The module is in the BuildMasterAutomation directory. Put that directory anywhere you want. 
- 
+
+To install, open the downloaded ZIP file. The module is in the BuildMasterAutomation directory. Put that directory anywhere you want.
+
 # Getting Started
 
 First, import the BuildMaster Automation module:
 
     Import-Module 'Path\To\BuildMasterAutomation'
-    
+
 If you put it in one of your `PSModulePath` directories, you can omit the path:
 
     Import-Module 'BuildMasterAutomation'
- 
+
 Next, create a connection object to the instance of BuildMaster you want to use along with the API key to use.
- 
+
 ***NOTE: Authentication to BuildMaster is done using an API key that is sent to BuildMaster as an HTTP header, which is visible to anyone listening on your network. Make sure your instance of BuildMaster is protected with SSL, otherwise malicous users will be able to see your API key and will be able to access your instance of BuildMaster.***
 
     $session = New-BMSession -Uri 'https://buildmaster.example.com' -ApiKey $apiKey
-    
+
 Now, you can create applications:
 
     New-BMApplication -Session $session -Name 'BuildMaster Automation'
-    
+
 You can create releases:
 
     New-BMRelease -Session $session -Application 'BuildMaster Automation' -Number '0.0' -Pipeline 'PowerShell Module'
-    
+
 To see a full list of available commands:
 
     Get-Command -Module 'BuildMasterAutomation'
-    
+
 You can always call an API using `Invoke-BMRestMethod`:
 
     Invoke-BMRestMethod -Session $session -Name 'release'
-    
+
 You can also call a native BuildMaster API with `Invoke-BMNativeApiMethod`:
 
-    Invoke-BMNativeApiMethod -Session $session -Name 'Pipelines_GetPipelines'
-    
+    Invoke-BMNativeApiMethod -Session $session -Name 'Applications_GetApplications'
+
 
 # Contributing
 
-Contributions are welcome and encouraged! First, [create your own copy of this repository by "forking" it](https://help.github.com/articles/fork-a-repo/). 
+Contributions are welcome and encouraged! First, [create your own copy of this repository by "forking" it](https://help.github.com/articles/fork-a-repo/).
 
 Next, [clone the repository to your local computer](https://help.github.com/articles/cloning-a-repository/).
 
 Finally, before you can write tests and code, you'll need to install the module's pre-requisites. Run:
 
     > .\init.ps1
-    
-This script will install modules needed to develop and run tests. It will also download and install a copy of BuildMaster including an instance of SQL Server 2005 Express named `BuildMaster`. All tests connect to this local instance of BuildMaster. 
+
+This script will install modules needed to develop and run tests. It will also download and install a copy of BuildMaster including an instance of SQL Server 2005 Express named `BuildMaster`. All tests connect to this local instance of BuildMaster.
 
 We use [Pester](https://github.com/pester/Pester) as our testing framework. A copy of Pester is saved to the repository root directory by `init.ps1`. To run tests, import Pester, and use `Invoke-Pester`:
 
     > Import-Module '.\Pester'
     > Invoke-Pester '.\Tests'
-    
-Test scripts go in the `Tests` directory. New functions go in the `BuildMasterAutomation\Functions` directory. 
+
+Test scripts go in the `Tests` directory. New functions go in the `BuildMasterAutomation\Functions` directory.
 

--- a/Tests/BuildMasterAutomationTest/BuildMasterAutomationTest.psm1
+++ b/Tests/BuildMasterAutomationTest/BuildMasterAutomationTest.psm1
@@ -15,8 +15,8 @@ if( -not $svcConfig )
     throw $bmNotInstalledMsg
 }
 
-$uri = $svcConfig.SelectSingleNode('/InedoAppConfig/WebServer').Attributes['Urls'].Value
-$uri = $uri -replace '\*',$env:COMPUTERNAME
+$url = $svcConfig.SelectSingleNode('/InedoAppConfig/WebServer').Attributes['Urls'].Value
+$url = $url -replace '\*',$env:COMPUTERNAME
 $connString = $svcConfig.SelectSingleNode('/InedoAppConfig/ConnectionString').InnerText
 
 $conn = New-Object 'Data.SqlClient.SqlConnection'
@@ -83,7 +83,7 @@ function New-BMTestApplication
     return New-BMApplication -Session $Session -Name $Name
 }
 
-$session = New-BMSession -Uri $uri -ApiKey $apiKey
+$session = New-BMSession -Url $url -ApiKey $apiKey
 
 function New-BMTestSession
 {
@@ -152,10 +152,10 @@ function GivenAPipeline
         $appParam['Application'] = $ForApplication
     }
 
-    return New-BMPipeline -Session $session -Name $Named @appParam
+    return Set-BMPipeline -Session $session -Name $Named @appParam -PassThru
 }
 
-function GivenAPackage
+function GivenABuild
 {
     [CmdletBinding(DefaultParameterSetName='WithAllTheTrimmings')]
     param(
@@ -173,13 +173,13 @@ function GivenAPackage
 
     if( $PSCmdlet.ParameterSetName -eq 'ForARelease' )
     {
-        return New-BMPackage -Session $session -Release $ForRelease
+        return New-BMBuild -Session $session -Release $ForRelease
     }
 
     $app = GivenAnApplication -Name $ForAnAppNamed
     $pipeline = GivenAPipeline -Named ('{0}.pipeline' -f $ForAnAppNamed)  -ForApplication $app
     $release = GivenARelease -Named ('{0}.release' -f $ForAnAppNamed) -ForApplication $app -WithNumber $ForReleaseNumber -UsingPipeline $pipeline
-    return New-BMPackage -Session $session -Release $release
+    return New-BMBuild -Session $session -Release $release
 }
 
 function ThenError
@@ -200,18 +200,7 @@ function ThenNoErrorWritten
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "")]
 $BMTestSession = $session
 
-Get-BMApplication -Session $session |
-    ForEach-Object {
-        Write-Debug -Message ('Deactivating and purging application {0,5} {1}.' -f $_.Application_Id,$_.Application_Name)
-        Disable-BMApplication -Session $session -ID $_.Application_Id
-        Invoke-BMNativeApiMethod -Session $session -Name 'Applications_PurgeApplicationData' -Method Post -Parameter @{ Application_Id  = $_.Application_Id }
-    }
-
-Invoke-BMNativeApiMethod -Session $session -Name 'Pipelines_GetPipelines' -Method Post -Parameter @{ } |
-    ForEach-Object {
-        Write-Debug -Message ('Deleting pipeline {0,5} {1}.' -f $_.Pipeline_Id,$_.Pipeline_Name)
-        Invoke-BMNativeApiMethod -Session $session -Name 'Pipelines_DeletePipeline' -Method Post -Parameter @{ Pipeline_Id = $_.Pipeline_Id }
-    }
-
+Get-BMApplication -Session $session | Remove-BMApplication -Session $session -Force
+Get-BMPipeline -Session $session | Remove-BMPipeline -Session $session
 
 Export-ModuleMember -Function '*' -Variable 'BMTestSession'

--- a/Tests/Get-BMBuild.Tests.ps1
+++ b/Tests/Get-BMBuild.Tests.ps1
@@ -16,17 +16,17 @@ BeforeAll {
 
             [Parameter(mandatory=$true,Position=1)]
             [object[]]
-            $Package
+            $Build
         )
 
-        foreach( $item in $Package )
+        foreach( $item in $Build )
         {
-            $foundPackage = $script:result | Where-Object { $_.id -eq $item.id }
-            $foundPackage | Should -BeNullOrEmpty
+            $foundBuild = $script:result | Where-Object { $_.id -eq $item.id }
+            $foundBuild | Should -BeNullOrEmpty
         }
     }
 
-    function ThenReturnedPackages
+    function ThenReturnedBuilds
     {
         param(
             [Parameter(Mandatory=$true,Position=0)]
@@ -35,42 +35,42 @@ BeforeAll {
 
             [Parameter(Mandatory=$true,Position=1)]
             [object[]]
-            $Package
+            $Build
         )
 
-        foreach( $item in $Package )
+        foreach( $item in $Build )
         {
             $script:result | Where-Object { $_.id -eq $item.id } | Should -Not -BeNullOrEmpty
         }
     }
 
-    function ThenReturnedPackage
+    function ThenReturnedBuild
     {
         param(
-            $Package
+            $Build
         )
 
         $script:result.Count | Should -Be 1
-        $script:result[0].id | Should -Be $Package.id
+        $script:result[0].id | Should -Be $Build.id
     }
 
-    function WhenGettingAllPackages
+    function WhenGettingAllBuilds
     {
-        $script:result = Get-BMPackage -Session $BMTestSession
+        $script:result = Get-BMBuild -Session $BMTestSession
     }
 
-    function WhenGettingPackage
+    function WhenGettingBuild
     {
         param(
             [Parameter(Mandatory=$true)]
             [object]
-            $Package
+            $Build
         )
 
-        $script:result = Get-BMPackage -Session $BMTestSession -Package $Package
+        $script:result = Get-BMBuild -Session $BMTestSession -Build $Build
     }
 
-    function WhenGettingPackagesByRelease
+    function WhenGettingBuildsByRelease
     {
         param(
             [Parameter(Mandatory=$true)]
@@ -78,92 +78,105 @@ BeforeAll {
             $Release
         )
 
-        $script:result = Get-BMPackage -Session $BMTestSession -Release $Release
+        $script:result = Get-BMBuild -Session $BMTestSession -Release $Release
     }
 }
 
-Describe 'Get-BMPackage' {
-    It 'should return all packages' {
+Describe 'Get-BMBuild' {
+    BeforeEach {
+        $Global:Error.Clear()
+        $script:result = @()
+    }
+
+    It 'should return all builds' {
         $pipeline = GivenAPipeline -Named $PSCommandPath
 
         $app1 = GivenAnApplication -Name $PSCommandPath
         $app1Release1 = GivenARelease -Named $PSCommandPath -ForApplication $app1 -WithNumber '1.0.0' -UsingPipeline $pipeline
-        $app1Release1Package1 = GivenAPackage -ForRelease $app1Release1
-        $app1Release1Package2 = GivenAPackage -ForRelease $app1Release1
+        $app1Release1Build1 = GivenABuild -ForRelease $app1Release1
+        $app1Release1Build2 = GivenABuild -ForRelease $app1Release1
 
         $app1Release2 = GivenARelease -Named $PSCommandPath -ForApplication $app1 -WithNumber '2.0.0' -UsingPipeline $pipeline
-        $app1Release2Package1 = GivenAPackage -ForRelease $app1Release2
+        $app1Release2Build1 = GivenABuild -ForRelease $app1Release2
 
         $app2 = GivenAnApplication -Name $PSCommandPath
         $app2Release1 = GivenARelease -Named $PSCommandPath -ForApplication $app2 -WithNumber '1.0.0' -UsingPipeline $pipeline
-        $app2Release1Package1 = GivenAPackage -ForRelease $app2Release1
-        $app2Release1Package2 = GivenAPackage -ForRelease $app2Release1
+        $app2Release1Build1 = GivenABuild -ForRelease $app2Release1
+        $app2Release1Build2 = GivenABuild -ForRelease $app2Release1
 
         $app2Release2 = GivenARelease -Named $PSCommandPath -ForApplication $app2 -WithNumber '2.0.0' -UsingPipeline $pipeline
-        $app2Release2Package1 = GivenAPackage -ForRelease $app2Release2
+        $app2Release2Build1 = GivenABuild -ForRelease $app2Release2
 
-        WhenGettingAllPackages
+        WhenGettingAllBuilds
 
-        ThenReturnedPackages 'all' $app1Release1Package1,$app1Release1Package2,$app1Release2Package1,$app2Release1Package1,$app2Release1Package2,$app2Release2Package1
+        ThenReturnedBuilds 'all' $app1Release1Build1,$app1Release1Build2,$app1Release2Build1,$app2Release1Build1,$app2Release1Build2,$app2Release2Build1
     }
 
-    It 'should return specific package using package object' {
-        $package = GivenAPackage -ForAnAppNamed $PSCommandPath -ForReleaseNumber '1.0.0'
-        WhenGettingPackage $package
-        ThenReturnedPackage $package
+    It 'should return specific build using build object' {
+        $build = GivenABuild -ForAnAppNamed $PSCommandPath -ForReleaseNumber '1.0.0'
+        WhenGettingBuild $build
+        ThenReturnedBuild $build
     }
 
-    It 'should return specific package using package id' {
-        $package = GivenAPackage -ForAnAppNamed $PSCommandPath -ForReleaseNumber '1.0.0'
-        WhenGettingPackage $package.id
-        ThenReturnedPackage $package
+    It 'should return specific build using build id' {
+        $build = GivenABuild -ForAnAppNamed $PSCommandPath -ForReleaseNumber '1.0.0'
+        WhenGettingBuild $build.id
+        ThenReturnedBuild $build
     }
 
-    It 'should return package when passed release object' {
+    It 'should return build when passed release object' {
         $pipeline = GivenAPipeline -Named $PSCommandPath
 
         $app1 = GivenAnApplication -Name $PSCommandPath
         $app1Release1 = GivenARelease -Named $PSCommandPath -ForApplication $app1 -WithNumber '1.0.0' -UsingPipeline $pipeline
-        $app1Release1Package1 = GivenAPackage -ForRelease $app1Release1
-        $app1Release1Package2 = GivenAPackage -ForRelease $app1Release1
+        $app1Release1Build1 = GivenABuild -ForRelease $app1Release1
+        $app1Release1Build2 = GivenABuild -ForRelease $app1Release1
 
         $app1Release2 = GivenARelease -Named $PSCommandPath -ForApplication $app1 -WithNumber '2.0.0' -UsingPipeline $pipeline
-        $app1Release2Package1 = GivenAPackage -ForRelease $app1Release2
+        $app1Release2Build1 = GivenABuild -ForRelease $app1Release2
 
         $app2 = GivenAnApplication -Name $PSCommandPath
         $app2Release1 = GivenARelease -Named $PSCommandPath -ForApplication $app2 -WithNumber '1.0.0' -UsingPipeline $pipeline
-        $app2Release1Package1 = GivenAPackage -ForRelease $app2Release1
-        $app2Release1Package2 = GivenAPackage -ForRelease $app2Release1
+        $app2Release1Build1 = GivenABuild -ForRelease $app2Release1
+        $app2Release1Build2 = GivenABuild -ForRelease $app2Release1
 
         $app2Release2 = GivenARelease -Named $PSCommandPath -ForApplication $app2 -WithNumber '2.0.0' -UsingPipeline $pipeline
-        $app2Release2Package1 = GivenAPackage -ForRelease $app2Release2
+        $app2Release2Build1 = GivenABuild -ForRelease $app2Release2
 
-        WhenGettingPackagesByRelease $app1Release1
-        ThenReturnedPackages 'that release''s' $app1Release1Package1,$app1Release1Package2
-        ThenDidNotReturn 'other releases''' $app1Release2Package1,$app2Release1Package1, $app2Release1Package2, $app2Release2Package1
+        WhenGettingBuildsByRelease $app1Release1
+        ThenReturnedBuilds 'that release''s' $app1Release1Build1,$app1Release1Build2
+        ThenDidNotReturn 'other releases''' $app1Release2Build1,$app2Release1Build1, $app2Release1Build2, $app2Release2Build1
     }
 
-    It 'should return package when passed release id' {
+    It 'should return build when passed release id' {
         $pipeline = GivenAPipeline -Named $PSCommandPath
 
         $app1 = GivenAnApplication -Name $PSCommandPath
         $app1Release1 = GivenARelease -Named $PSCommandPath -ForApplication $app1 -WithNumber '1.0.0' -UsingPipeline $pipeline
-        $app1Release1Package1 = GivenAPackage -ForRelease $app1Release1
-        $app1Release1Package2 = GivenAPackage -ForRelease $app1Release1
+        $app1Release1Build1 = GivenABuild -ForRelease $app1Release1
+        $app1Release1Build2 = GivenABuild -ForRelease $app1Release1
 
         $app1Release2 = GivenARelease -Named $PSCommandPath -ForApplication $app1 -WithNumber '2.0.0' -UsingPipeline $pipeline
-        $app1Release2Package1 = GivenAPackage -ForRelease $app1Release2
+        $app1Release2Build1 = GivenABuild -ForRelease $app1Release2
 
         $app2 = GivenAnApplication -Name $PSCommandPath
         $app2Release1 = GivenARelease -Named $PSCommandPath -ForApplication $app2 -WithNumber '1.0.0' -UsingPipeline $pipeline
-        $app2Release1Package1 = GivenAPackage -ForRelease $app2Release1
-        $app2Release1Package2 = GivenAPackage -ForRelease $app2Release1
+        $app2Release1Build1 = GivenABuild -ForRelease $app2Release1
+        $app2Release1Build2 = GivenABuild -ForRelease $app2Release1
 
         $app2Release2 = GivenARelease -Named $PSCommandPath -ForApplication $app2 -WithNumber '2.0.0' -UsingPipeline $pipeline
-        $app2Release2Package1 = GivenAPackage -ForRelease $app2Release2
+        $app2Release2Build1 = GivenABuild -ForRelease $app2Release2
 
-        WhenGettingPackagesByRelease $app1Release1.id
-        ThenReturnedPackages 'that release''s' $app1Release1Package1,$app1Release1Package2
-        ThenDidNotReturn 'other releases''' $app1Release2Package1,$app2Release1Package1, $app2Release1Package2, $app2Release2Package1
+        WhenGettingBuildsByRelease $app1Release1.id
+        ThenReturnedBuilds 'that release''s' $app1Release1Build1,$app1Release1Build2
+        ThenDidNotReturn 'other releases''' $app1Release2Build1,$app2Release1Build1, $app2Release1Build2, $app2Release2Build1
+    }
+
+    It 'should export obsolete Get-BMPackage' {
+        $warnings = @()
+        $build = GivenABuild -ForAnAppNamed $PSCommandPath -ForReleaseNumber '1.0.0'
+        $script:result = Get-BMPackage -Session $BMTestSession -Package $build -WarningVariable 'warnings'
+        ThenReturnedBuild $build
+        $warnings | Should -Not -BeNullOrEmpty
     }
 }

--- a/Tests/Get-BMRelease.Tests.ps1
+++ b/Tests/Get-BMRelease.Tests.ps1
@@ -8,13 +8,15 @@ BeforeAll {
     $script:session = New-BMTestSession
     $script:app = New-BMTestApplication -Session $script:session -CommandPath $PSCommandPath
     $script:pipelineName = ('{0}.{1}' -f (Split-Path -Path $PSCommandPath -Leaf),[IO.Path]::GetRandomFileName())
-    $script:pipeline =
-        New-BMPipeline -Session $script:session -Name $script:pipelineName -Application $script:app -Color '#ffffff'
+    $script:pipeline = Set-BMPipeline -Session $script:session `
+                                      -Name $script:pipelineName `
+                                      -Application $script:app `
+                                      -Color '#ffffff' -PassThru
     $script:develop = New-BMRelease -Session $script:session `
                                     -Application $script:app `
                                     -Number '1.0' `
                                     -Pipeline $script:pipeline `
-                                    -Name 'develop'
+                                    -Name 'script:develop'
     $script:release = New-BMRelease -Session $script:session `
                                     -Application $script:app `
                                     -Number '2.0' `
@@ -24,7 +26,7 @@ BeforeAll {
                                    -Application $script:app `
                                    -Number '3.0' `
                                    -Pipeline $script:pipeline `
-                                   -Name 'master'
+                                   -Name 'script:master'
 }
 
 Describe 'Get-BMRelease' {
@@ -38,9 +40,9 @@ Describe 'Get-BMRelease' {
     }
 
     It 'should return release by name' {
-        $release = Get-BMRelease -Session $script:session -Application $script:app -Name 'develop'
+        $release = Get-BMRelease -Session $script:session -Application $script:app -Name 'script:develop'
         $release | Should -Not -BeNullOrEmpty
-        $release.name | Should -Be 'develop'
+        $release.name | Should -Be 'script:develop'
     }
 
     It 'should return all releases' {

--- a/Tests/Invoke-BMNativeApiMethod.Tests.ps1
+++ b/Tests/Invoke-BMNativeApiMethod.Tests.ps1
@@ -12,7 +12,7 @@ Describe 'Invoke-BMNativeApiMethod' {
     It 'should return a result when making GET requests and WhatIf is true' {
         $variable = @{
                         'Variable_Name' = 'Fubar';
-                        'Variable_Value' = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes('Snafu'))
+                        'Variable_Value' = ('Snafu' | ConvertTo-BMNativeApiByteValue);
                         'ValueType_Code' = 'string';
                         'Sensitive_Indicator' = 'False';
                         'EvaluateVariables_Indicator' = 'False';
@@ -24,10 +24,9 @@ Describe 'Invoke-BMNativeApiMethod' {
 
     It 'should not make the HTTP request when making POST requests and WhatIf is true' {
         Get-BMVariable -Session $script:session | Remove-BMVariable -Session $script:session
-        $encodedValue = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes('Snafu'))
         $variable = @{
                         'Variable_Name' = 'Fubar';
-                        'Variable_Value' = $encodedValue;
+                        'Variable_Value' = ('Snafu' | ConvertTo-BMNativeApiByteValue);
                         'ValueType_Code' = 'string';
                         'Sensitive_Indicator' = 'False';
                         'EvaluateVariables_Indicator' = 'False';

--- a/Tests/New-BMApplication.Tests.ps1
+++ b/Tests/New-BMApplication.Tests.ps1
@@ -25,7 +25,7 @@ Describe 'New-BMApplication' {
         $appName = ('New-BMApplication.{0}' -f [IO.Path]::GetRandomFileName())
         New-BMApplication -Session $script:session -Name $appName
         $app2 = New-BMApplication -Session $script:session -Name $appName -ErrorAction SilentlyContinue
-        $Global:Error | Should -Match 'duplicate key'
+        $Global:Error | Should -Match 'already exists'
         $app2 | Should -BeNullOrEmpty
     }
 
@@ -34,12 +34,10 @@ Describe 'New-BMApplication' {
         $app = New-BMApplication -Session $script:session `
                                  -Name $appName `
                                  -ReleaseNumberSchemeName DateBased `
-                                 -BuildNumberSchemeName DateTimeBased `
-                                 -AllowMultipleActiveBuilds
+                                 -BuildNumberSchemeName DateTimeBased
         $app | Should -Not -BeNullOrEmpty
         $app.ReleaseNumber_Scheme_Name | Should -Be 'DateBased'
         $app.BuildNumber_Scheme_Name | Should -Be 'DateTimeBased'
-        $app.AllowMultipleActiveBuilds_Indicator | Should -Be $true
     }
 
     It 'should create application in an application group' {
@@ -48,7 +46,7 @@ Describe 'New-BMApplication' {
                                                -Parameter @{ ApplicationGroup_Name = 'TestBMAppGroup' } `
                                                -Method Post
         $appName = ('New-BMApplication.{0}' -f [IO.Path]::GetRandomFileName())
-        $app = New-BMApplication -Session $script:session -Name $appName -ApplicationGroupId $appGroupID
+        $app = New-BMApplication -Session $script:session -Name $appName -ApplicationGroup $appGroupID
         $app | Should -Not -BeNullOrEmpty
         $app.ApplicationGroup_Name | Should -Be 'TestBMAppGroup'
     }

--- a/Tests/New-BMBuild.Tests.ps1
+++ b/Tests/New-BMBuild.Tests.ps1
@@ -9,15 +9,15 @@ BeforeAll {
     $script:app = New-BMTestApplication -Session $script:session -CommandPath $PSCommandPath
     $script:pipelineName = ('{0}.{1}' -f (Split-Path -Path $PSCommandPath -Leaf),[IO.Path]::GetRandomFileName())
     $script:pipeline =
-        New-BMPipeline -Session $script:session -Name $script:pipelineName -Application $script:app -Color '#ffffff'
+    $script:pipeline = Set-BMPipeline -Session $session -Name $pipelineName -Application $app -Color '#ffffff' -PassThru
     $script:release =
         New-BMRelease -Session $script:session -Application $script:app -Number '1.0' -Pipeline $script:pipeline
 
-    function Assert-Package
+    function Assert-Build
     {
         param(
             [Parameter(ValueFromPipeline=$true)]
-            $Package,
+            $Build,
 
             [object]
             $HasNumber,
@@ -26,19 +26,19 @@ BeforeAll {
             $HasVariable
         )
 
-        $Package | Should -Not -BeNullOrEmpty
-        $Package = Get-BMPackage -Session $script:session -Package $package
-        $Package | Should -Not -BeNullOrEmpty
-        $Package.number | Should -Be $HasNumber
-        $Package.applicationId | Should -Be $script:app.Application_Id
-        $Package.pipelineId | Should -Be $script:pipeline.Pipeline_Id
-        $Package.releaseId | Should -Be $script:release.id
+        $Build | Should -Not -BeNullOrEmpty
+        $Build = Get-BMBuild -Session $script:session -Build $Build
+        $Build | Should -Not -BeNullOrEmpty
+        $Build.number | Should -Be $HasNumber
+        $Build.applicationId | Should -Be $script:app.Application_Id
+        $Build.pipelineName | Should -Be $pipeline.Pipeline_Name
+        $Build.releaseId | Should -Be $script:release.id
 
         if( $HasVariable )
         {
-            $variable = Invoke-BMNativeApiMethod -Session $script:session `
-                                                 -Name 'Variables_GetPackageVariables' `
-                                                 -Parameter @{ 'Build_Id' = $Package.id } `
+            $variable = Invoke-BMNativeApiMethod -Session $session `
+                                                 -Name 'Variables_GetBuildVariables' `
+                                                 -Parameter @{ 'Build_Id' = $Build.id } `
                                                  -Method Post
 
             foreach( $key in $HasVariable.Keys )
@@ -46,32 +46,39 @@ BeforeAll {
                 $actualVariable = $variable |  Where-Object { $_.Variable_Name -eq $key }
                 $actualVariable | Should -Not -BeNullOrEmpty
                 $value = $actualVariable.Variable_Value
-                $value = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($value))
+                $value = $value | ConvertFrom-BMNativeApiByteValue
                 $value | Should -Be $HasVariable[$key]
             }
         }
     }
 }
 
-Describe 'New-BMPackage' {
-    It 'should create package' {
-        New-BMPackage -Session $script:session -Release $script:release |
-            Assert-Package -HasNumber 1
+Describe 'New-BMBuild' {
+    It 'should create build' {
+        New-BMBuild -Session $script:session -Release $script:release |
+            Assert-Build -HasNumber 1
     }
 
-    It 'should create package with custom name' {
-        New-BMPackage -Session $script:session -Release $script:release -PackageNumber '56.develop' |
-            Assert-Package -HasNumber '56.develop'
+    It 'should create build with custom name' {
+        New-BMBuild -Session $script:session -Release $script:release -BuildNumber '56.develop' |
+            Assert-Build -HasNumber '56.develop'
     }
 
-    It 'should create package with variables' {
+    It 'should create build with variables' {
         $variable = @{ 'ProGetPackageName' = '17.125.56+develop.deadbee' }
-        New-BMPackage -Session $script:session -Release $script:release -PackageNumber '3' -Variable $variable |
-            Assert-Package -HasNumber '3' -HasVariable $variable
+        New-BMBuild -Session $script:session -Release $script:release -BuildNumber '3' -Variable $variable |
+            Assert-Build -HasNumber '3' -HasVariable $variable
     }
 
-    It 'create package with release number and application' {
-        New-BMPackage -Session $script:session -ReleaseNumber $script:release.number -Application $script:app |
-            Assert-Package -HasNumber '4'
+    It 'create build with release number and application' {
+        New-BMBuild -Session $script:session -ReleaseNumber $script:release.number -Application $script:app |
+            Assert-Build -HasNumber '4'
+    }
+
+    It 'should export obsolete New-BMPackage' {
+        $warnings = @()
+        New-BMPackage -Session $script:session -Release $script:release -WarningVariable 'warnings' |
+            Assert-Build -HasNumber '5'
+        $warnings | Should -Not -BeNullOrEmpty
     }
 }

--- a/Tests/New-BMRelease.Tests.ps1
+++ b/Tests/New-BMRelease.Tests.ps1
@@ -8,7 +8,7 @@ BeforeAll {
     $script:session = New-BMTestSession
     $script:app = New-BMTestApplication -Session $script:session -CommandPath $PSCommandPath
     $script:pipelineName = ('{0}.{1}' -f (Split-Path -Path $PSCommandPath -Leaf),[IO.Path]::GetRandomFileName())
-    $script:pipeline = New-BMPipeline -Session $script:session -Name $script:pipelineName -Application $script:app -Color '#ffffff'
+    $script:pipeline = Set-BMPipeline -Session $session -Name $pipelineName -Application $app -Color '#ffffff' -PassThru
 
     function Assert-Release
     {
@@ -29,7 +29,7 @@ BeforeAll {
             $newRelease.id | Should -Be $Release.id
             $Release.applicationId | Should -Be $script:app.Application_Id
             $Release.number | Should -Be $HasNumber
-            $Release.pipelineId | Should -Be $script:pipeline.Pipeline_Id
+            $Release.pipelineName | Should -Be $pipeline.Pipeline_Name
 
             if( -not $HasName )
             {
@@ -50,21 +50,14 @@ Describe 'New-BMRelease' {
         $releaseNumber = New-TestReleaseNumber
         $script:app |
             New-BMRelease -Session $script:session -Number $releaseNumber -Pipeline $script:pipeline |
-            Assert-Release -HasNumber $releaseNumber
-    }
-
-    It 'should create release when piping application ID' {
-        $releaseNumber = New-TestReleaseNumber
-        $script:app.Application_Id |
-            New-BMRelease -Session $script:session -Number $releaseNumber -Pipeline $script:pipeline.Pipeline_Id |
-            Assert-Release -HasNumber $releaseNumber
+            Assert-Release -HasNumber $releaseNumber 
     }
 
     It 'should create release when piping application name' {
         $releaseNumber = New-TestReleaseNumber
         $script:app.Application_Name |
             New-BMRelease -Session $script:session -Number $releaseNumber -Pipeline $script:pipeline.Pipeline_Name |
-            Assert-Release -HasNumber $releaseNumber
+            Assert-Release -HasNumber $releaseNumber 
     }
 
     It 'should set release name' {

--- a/Tests/New-BMSession.Tests.ps1
+++ b/Tests/New-BMSession.Tests.ps1
@@ -8,12 +8,12 @@ BeforeAll {
 
 Describe 'New-BMSession' {
     It 'should return a session object' {
-        $uri = 'https://fubar.snafu'
+        $url = 'https://fubar.snafu'
         $key = 'fubarsnafu'
 
-        $session = New-BMSession -Uri $uri -ApiKey $key
+        $session = New-BMSession -Url $url -ApiKey $key
         $session | Should -Not -BeNullOrEmpty
-        $session.Uri | Should -Be ([uri]$uri)
+        $session.Url | Should -Be ([uri]$url)
         $session.ApiKey | Should -Be $key
     }
 }

--- a/Tests/Publish-BMReleaseBuild.Tests.ps1
+++ b/Tests/Publish-BMReleaseBuild.Tests.ps1
@@ -9,69 +9,37 @@ BeforeAll {
     $script:app = New-BMTestApplication -Session $script:session -CommandPath $PSCommandPath
     $script:pipelineName = ('{0}.{1}' -f (Split-Path -Path $PSCommandPath -Leaf),[IO.Path]::GetRandomFileName())
 
-    # In order to deploy, a pipeline must have at least one stage that executes one plan.
-    $script:pipeline = New-BMPipeline -Session $script:session `
+    $stages = & {
+        New-BMPipelineStageTargetObject -PlanName 'Integration' -EnvironmentName 'Integration' -AllServers |
+            New-BMPipelineStageObject -Name 'Publish-BMReleaseBuild.Fubar' |
+            Write-Output
+
+        New-BMPipelineStageTargetObject -PlanName 'Testing' -EnvironmentName 'Testing' -AllServers |
+            New-BMPipelineStageObject -Name 'Publish-BMReleaseBuild.Fubar2' |
+            Write-Output
+    }
+
+    $postDeployOptions = New-BMPipelinePostDeploymentOptionsObject -MarkDeployed $false
+
+    $script:pipeline = Set-BMPipeline -Session $script:session `
                                       -Name $script:pipelineName `
                                       -Application $script:app `
                                       -Color '#ffffff' `
-                                      -Stage @'
-<Inedo.BuildMaster.Pipelines.PipelineStage Assembly="BuildMaster">
-    <Properties Name="Fubar" TargetExecutionMode="Parallel" AutoPromote="False">
-        <Targets>
-            <Inedo.BuildMaster.Pipelines.PipelineStageTarget Assembly="BuildMaster">
-                <Properties PlanName="Fubar" EnvironmentName="Integration" DefaultServerContext="None">
-                    <ServerNames />
-                    <ServerRoleNames />
-                </Properties>
-            </Inedo.BuildMaster.Pipelines.PipelineStageTarget>
-        </Targets>
-        <Gate>
-            <Inedo.BuildMaster.Pipelines.PipelineStageGate Assembly="BuildMaster">
-                <Properties>
-                    <UserApprovals />
-                    <GroupApprovals />
-                    <AutomaticApprovals />
-                </Properties>
-            </Inedo.BuildMaster.Pipelines.PipelineStageGate>
-        </Gate>
-        <PostDeploymentEventListeners />
-        <Variables>{}</Variables>
-    </Properties>
-</Inedo.BuildMaster.Pipelines.PipelineStage>
-'@, @'
-<Inedo.BuildMaster.Pipelines.PipelineStage Assembly="BuildMaster">
-    <Properties Name="Fubar2" TargetExecutionMode="Parallel" AutoPromote="False">
-        <Targets>
-            <Inedo.BuildMaster.Pipelines.PipelineStageTarget Assembly="BuildMaster">
-                <Properties PlanName="Fubar" EnvironmentName="Integration" DefaultServerContext="None">
-                    <ServerNames />
-                    <ServerRoleNames />
-                </Properties>
-            </Inedo.BuildMaster.Pipelines.PipelineStageTarget>
-        </Targets>
-        <Gate>
-            <Inedo.BuildMaster.Pipelines.PipelineStageGate Assembly="BuildMaster">
-                <Properties>
-                    <UserApprovals />
-                    <GroupApprovals />
-                    <AutomaticApprovals />
-                </Properties>
-            </Inedo.BuildMaster.Pipelines.PipelineStageGate>
-        </Gate>
-        <PostDeploymentEventListeners />
-        <Variables>{}</Variables>
-    </Properties>
-</Inedo.BuildMaster.Pipelines.PipelineStage>
-'@
-    $release = New-BMRelease -Session $script:session -Application $script:app -Number '1.0' -Pipeline $script:pipeline
+                                      -Stage $stages `
+                                      -PostDeploymentOption $postDeployOptions `
+                                      -PassThru `
+                                      -ErrorAction Stop
+
+    $script:release =
+        New-BMRelease -Session $script:session -Application $script:app -Number '1.0' -Pipeline $script:pipeline
     Enable-BMEnvironment -Session $script:session -Name 'Integration'
 
-    function GivenBMReleasePackage
+    function GivenBMReleaseBuild
     {
-        $Script:package = New-BMPackage -Session $script:session -Release $release
+        $script:build = New-BMBuild -Session $script:session -Release $script:release
     }
 
-    function WhenDeployingPackage
+    function WhenDeployingBuild
     {
         param(
             [string]
@@ -88,7 +56,8 @@ BeforeAll {
             $optionalParam['Force'] = $true
         }
 
-        $Script:deployment = Publish-BMReleasePackage -Session $script:session -Package $package $ToStage @optionalParam
+        $Script:deployment =
+            Publish-BMReleaseBuild -Session $script:session -Build $script:build $ToStage @optionalParam
     }
 
     function ThenShouldNotThrowErrors
@@ -96,52 +65,78 @@ BeforeAll {
         $Global:Error | Should -BeNullOrEmpty
     }
 
-    function ThenPackageShouldBeDeployed
+    function ThenBuildShouldBeDeployed
     {
         param(
             [string]
             $ToStage
         )
 
-        $deployment | Should -Not -BeNullOrEmpty
-        $deployment = Invoke-BMRestMethod -Session $script:session -Name 'releases/packages/deployments' -Parameter @{ packageId = $package.id } -Method Post
-        $deployment | Should -Not -BeNullOrEmpty
-        $deployment.pipelineId | Should -Be $script:pipeline.pipeline_id
-        $deployment.pipelineStageName | Should -Be $ToStage
-        $deployment.releaseId | Should -Be $release.id
-        $deployment.status | Should -Be 'pending'
+        $timer = [Diagnostics.Stopwatch]::StartNew()
+        $script:deployment | Should -Not -BeNullOrEmpty
+        $deploymentId = $script:deployment.id
+        $expectedStatuses = @('executing', 'pending', 'succeeded')
+        do
+        {
+            $script:deployment = Invoke-BMRestMethod -Session $script:session `
+                                                     -Name 'releases/builds/deployments' `
+                                                     -Parameter @{ deploymentId = $deploymentId } `
+                                                     -Method Post
+
+            if (-not $script:deployment -or $script:deployment.status -notin $expectedStatuses)
+            {
+                Start-Sleep -Milliseconds 100
+                continue
+            }
+
+            break
+        }
+        while ($timer.Elapsed.TotalSeconds -lt 10)
+
+        $script:deployment | Should -Not -BeNullOrEmpty
+        $script:deployment.pipelineName | Should -Be $script:pipeline.Pipeline_Name
+        $script:deployment.pipelineStageName | Should -Be $ToStage
+        $script:deployment.releaseId | Should -Be $script:release.id
+        $script:deployment.status | Should -BeIn $expectedStatuses
     }
 }
 
-Describe 'Publish-BMReleasePackage' {
-    It 'should publish using package object' {
-        GivenBMReleasePackage
-        WhenDeployingPackage
+Describe 'Publish-BMReleaseBuild' {
+    It 'should publish using build object' {
+        GivenBMReleaseBuild
+        WhenDeployingBuild
         ThenShouldNotThrowErrors
-        ThenPackageShouldBeDeployed -ToStage 'Fubar'
+        ThenBuildShouldBeDeployed -ToStage 'Publish-BMReleaseBuild.Fubar'
     }
 
     It 'should deploy to specific stage' {
-        GivenBMReleasePackage
-        WhenDeployingPackage -ToStage 'Fubar2'
+        GivenBMReleaseBuild
+        WhenDeployingBuild -ToStage 'Publish-BMReleaseBuild.Fubar2'
         ThenShouldNotThrowErrors
-        ThenPackageShouldBeDeployed -ToStage 'Fubar2'
+        ThenBuildShouldBeDeployed -ToStage 'Publish-BMReleaseBuild.Fubar2'
     }
 
-    It 'should fail if package does not exist' {
+    It 'should fail if build does not exist' {
         $Global:Error.Clear()
 
-        $deployment = Publish-BMReleasePackage -Session $script:session -Package ([int32]::MaxValue) -ErrorAction SilentlyContinue
+        $deployment = Publish-BMReleaseBuild -Session $script:session -Build ([int32]::MaxValue) -ErrorAction SilentlyContinue
         $deployment | Should -BeNullOrEmpty
         $Global:Error.Count | Should -Be 1
     }
 
     It 'should force a deploy' {
-        GivenBMReleasePackage
+        GivenBMReleaseBuild
         Mock -CommandName 'Invoke-BMRestMethod' -ModuleName 'BuildMasterAutomation'
-        WhenDeployingPackage -ToStage 'Fubar2' -Force
+        WhenDeployingBuild -ToStage 'Integration' -Force
         Assert-MockCalled -CommandName 'Invoke-BMRestMethod' `
                           -ModuleName 'BuildMasterAutomation' `
                           -ParameterFilter { $Parameter['force'] -eq 'true' }
+    }
+
+    It 'should export obsolete Publish-BMReleasePackage' {
+        GivenBMReleaseBuild
+        $script:deployment = Publish-BMReleasePackage -Session $script:session -Package $script:build
+        ThenShouldNotThrowErrors
+        ThenBuildShouldBeDeployed -ToStage 'Publish-BMReleaseBuild.Fubar'
     }
 }

--- a/Tests/Remove-BMServer.Tests.ps1
+++ b/Tests/Remove-BMServer.Tests.ps1
@@ -42,10 +42,9 @@ BeforeAll {
         [CmdletBinding()]
         param(
             [Parameter(Mandatory)]
-            [string]$Named,
+            [String]$Named,
 
-            [Switch]
-            $WhatIf
+            [switch] $WhatIf
         )
 
         $optionalParams = @{ }
@@ -72,9 +71,9 @@ Describe 'Remove-BMServer' {
         ThenServerDoesNotExist -Named 'Fubar'
     }
 
-    It 'should ignore when server does not exist' {
-        WhenRemovingServer -Named 'IDoNotExist'
-        ThenNoErrorWritten
+    It 'should reject when server does not exist' {
+        WhenRemovingServer -Named 'IDoNotExist' -ErrorAction SilentlyContinue
+        ThenError 'server .* does not exist'
         ThenServerDoesNotExist -Named 'IDoNotExist'
     }
 
@@ -87,6 +86,7 @@ Describe 'Remove-BMServer' {
 
     It 'should encode server name' {
         Mock -CommandName 'Invoke-BMRestMethod' -ModuleName 'BuildMasterAutomation'
+        Mock -CommandName 'Get-BMServer' -ModuleName 'BuildMasterAutomation' -MockWith { [pscustomobject]@{} }
         WhenRemovingServer -Named 'u r i?&'
         Assert-MockCalled -CommandName 'Invoke-BMRestMethod' `
                           -ModuleName 'BuildMasterAutomation' `

--- a/Tests/Remove-BMServerRole.Tests.ps1
+++ b/Tests/Remove-BMServerRole.Tests.ps1
@@ -72,10 +72,16 @@ Describe 'Remove-BMServerRole' {
         ThenRoleDoesNotExist -Named 'Fubar'
     }
 
-    It 'should ignore missing role' {
-        WhenRemovingRole -Named 'IDoNotExist'
-        ThenNoErrorWritten
+    It 'should reject missing role' {
+        WhenRemovingRole -Named 'IDoNotExist' -ErrorAction SilentlyContinue
+        ThenError 'server role .* does not exist'
         ThenRoleDoesNotExist -Named 'IDoNotExist'
+    }
+
+    It 'should ignore errors' {
+        WhenRemovingRole -Named 'IDoNotExist2' -ErrorAction Ignore
+        ThenNoErrorWritten
+        ThenRoleDoesNotExist -Named 'IDoNotExist2'
     }
 
     It 'should support WhatIf' {

--- a/Tests/Stop-BMRelease.Tests.ps1
+++ b/Tests/Stop-BMRelease.Tests.ps1
@@ -7,7 +7,7 @@ BeforeAll {
 
     $session = New-BMTestSession
     $app = New-BMTestApplication $session -CommandPath $PSCommandPath
-    $pipeline = New-BMPipeline -Session $session -Name $app.Application_name -Application $app
+    $pipeline = Set-BMPipeline -Session $session -Name $app.Application_Name -Application $app -PassThru
 
     function GivenARelease
     {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,33 +7,31 @@ skip_branch_with_pr: true
 build:
   verbosity: minimal
 
-services: mssql2017
-
 test: off
 
 environment:
   WHISKEY_DISABLE_ERROR_FORMAT: True
   matrix:
-  - job_name: PowerShell 7.2 on Windows
-    job_group: pwsh
-    appveyor_build_worker_image: Visual Studio 2022
-
-# No SQL 2017.
-#   - job_name: Windows PowerShell 5.1/.NET 4.6.2
-#     job_group: ps
-#     appveyor_build_worker_image: Visual Studio 2013
+  - job_name: Windows PowerShell 5.1/.NET 4.6.2
+    job_group: ps_sql2014
+    appveyor_build_worker_image: Visual Studio 2013
 
   - job_name: Windows PowerShell 5.1/.NET 4.8
-    job_group: ps
+    job_group: ps_sql2019
     appveyor_build_worker_image: Visual Studio 2019
 
   - job_name: PowerShell 6.2 on Windows
-    job_group: pwsh
+    job_group: pwsh_sql2016
     appveyor_build_worker_image: Visual Studio 2015
 
   - job_name: PowerShell 7.1 on Windows
-    job_group: pwsh
+    job_group: pwsh_sql2017
     appveyor_build_worker_image: Visual Studio 2019
+
+  - job_name: PowerShell 7.2 on Windows
+    job_group: pwsh_sql2019
+    appveyor_build_worker_image: Visual Studio 2022
+
 
 
 artifacts:
@@ -41,22 +39,51 @@ artifacts:
 
 
 for:
-# Build in Windows PowerShell
 - matrix:
     only:
-    - job_group: ps
+    - job_group: ps_sql2014
+  services: mssql2014
+  environment:
+    SQL_INSTANCE_NAME: SQL2014
   build_script:
-  - ps: |
+  - ps: &ps |
         $ProgressPreference = 'SilentlyContinue'
         iwr https://raw.githubusercontent.com/webmd-health-services/Prism/main/Scripts/init.ps1 | iex | Format-Table
         .\build.ps1
 
-# Build in PowerShell
 - matrix:
     only:
-    - job_group: pwsh
+    - job_group: ps_sql2019
+  services: mssql2019
+  environment:
+    SQL_INSTANCE_NAME: SQL2019
+  init: net start mssql$sql2019
   build_script:
-  - pwsh: |
-        $ProgressPreference = 'SilentlyContinue'
-        iwr https://raw.githubusercontent.com/webmd-health-services/Prism/main/Scripts/init.ps1 | iex | Format-Table
-        ./build.ps1
+  - ps: *ps
+
+- matrix:
+    only:
+    - job_group: pwsh_sql2016
+  services: mssql2016
+  environment:
+    SQL_INSTANCE_NAME: SQL2016
+  build_script:
+  - pwsh: *ps
+
+- matrix:
+    only:
+    - job_group: pwsh_sql2017
+  services: mssql2017
+  environment:
+    SQL_INSTANCE_NAME: SQL2017
+  build_script:
+  - pwsh: *ps
+
+- matrix:
+    only:
+    - job_group: pwsh_sql2019
+  environment:
+    SQL_INSTANCE_NAME: SQL2019
+  init: net start mssql$sql2019
+  build_script:
+  - pwsh: *ps

--- a/init.ps1
+++ b/init.ps1
@@ -29,7 +29,7 @@ $InformationPreference = 'Continue'
 
 $runningUnderAppVeyor = (Test-Path -Path 'env:APPVEYOR')
 
-$version = '6.1.28'
+$version = '6.2.33'
 Write-Verbose -Message ('Testing BuildMaster {0}' -f $version)
 $sqlServer = $null
 $installerPath = 'SQL'

--- a/init.ps1
+++ b/init.ps1
@@ -36,41 +36,36 @@ $installerPath = 'SQL'
 $installerUri = 'sql'
 $dbParam = '/InstallSqlExpress'
 
-$sqlServers = @()
-if( (Test-Path -Path 'env:APPVEYOR') )
-{
-    $sqlServers = Get-Item -Path ('SQLSERVER:\SQL\{0}\SQL2017' -f [Environment]::MachineName)
-}
-else
-{
-    $sqlServers = Get-ChildItem -Path ('SQLSERVER:\SQL\{0}' -f [Environment]::MachineName)
-}
+Get-ChildItem -Path 'env:' | Format-Table
 
-foreach( $item in $sqlServers )
-{
-    if( $item.Status -ne [Microsoft.SqlServer.Management.Smo.ServerStatus]::Online )
-    {
-        Write-Verbose -Message ('Skipping SQL Server instance "{0}": "{1}".' -f $item.Name,$item.Status)
-        continue
-    }
-
-    $item | Format-List | Out-String | Write-Verbose
-
-    if( -not $item.InstanceName -or $item.InstanceName -in @( 'Inedo', 'SQL2017' ) )
-    {
-        Write-Verbose -Message ('Found SQL Server instance "{0}": "{1}".' -f $item.Name,$item.Status)
-        $installerPath = 'NO{0}' -f $installerPath
-        $installerUri = 'no{0}' -f $installerUri
-        $sqlServer = $item
-        $credentials = 'Integrated Security=true;'
-        if( $runningUnderAppVeyor )
+$machineSqlPath = Join-Path -Path 'SQLSERVER:\SQL' -ChildPath ([Environment]::MachineName)
+$sqlServer =
+    Get-ChildItem -Path $machineSqlPath |
+    Where-Object {
+        if (Test-Path -Path 'env:SQL_INSTANCE_NAME')
         {
-            $credentials = 'User ID=sa;Password=Password12!'
+            return ($_.DisplayName -eq $env:SQL_INSTANCE_NAME)
         }
-        $dbParam = '"/ConnectionString=Server={0};Database=BuildMaster;{1}"' -f $sqlServer.Name,$credentials
-        break
+    } |
+    Where-Object { $_ | Get-Member -Name 'Status' } |
+    Where-Object { $_.Status -eq [Microsoft.SqlServer.Management.Smo.ServerStatus]::Online }
+    Sort-Object -Property 'Version' -Descending |
+    Select-Object -First 1
+
+if ($sqlServer)
+{
+    $sqlServer | Format-Table -Auto
+
+    $installerPath = 'NO{0}' -f $installerPath
+    $installerUri = 'no{0}' -f $installerUri
+    $credentials = 'Integrated Security=true;'
+    if( $runningUnderAppVeyor )
+    {
+        $credentials = 'User ID=sa;Password=Password12!'
     }
+    $dbParam = '"/ConnectionString=Server={0};Database=BuildMaster;{1}"' -f $sqlServer.Name,$credentials
 }
+
 
 $installerPath = Join-Path -Path $PSScriptRoot -ChildPath ('.output\BuildMasterInstaller{0}-{1}.exe' -f $installerPath,$version)
 $installerUri = 'https://my.inedo.com/services/legacy/downloads/buildmaster/{0}/{1}.exe' -f $installerUri,$version

--- a/whiskey.yml
+++ b/whiskey.yml
@@ -22,6 +22,14 @@ Build:
     DeleteSourceFiles: true
     TextSeparator: "$(NewLine)$(NewLine)"
 
+- CopyFile:
+    Path:
+    - LICENSE
+    - NOTICE
+    - README.md
+    - CHANGELOG.md
+    DestinationDirectory: BuildMasterAutomation
+
 - PublishPowerShellModule:
     Path: BuildMasterAutomation
 


### PR DESCRIPTION
* Pipelines_* native API replaced with Rafts_* API (i.e. pipelines are now stored in rafts as raft items).
* Packages renamed to Builds.