### PR TITLE
4.1.0

### DIFF
--- a/BuildMasterAutomation/BuildMasterAutomation.psd1
+++ b/BuildMasterAutomation/BuildMasterAutomation.psd1
@@ -12,7 +12,7 @@
     RootModule = 'BuildMasterAutomation.psm1'
 
     # Version number of this module.
-    ModuleVersion = '4.0.1'
+    ModuleVersion = '4.1.0'
 
     # ID used to uniquely identify this module
     GUID = 'cc5a1865-e5f8-45f2-b0d3-317a1611a965'

--- a/BuildMasterAutomation/Functions/ConvertFrom-BMOtterScriptExpression.ps1
+++ b/BuildMasterAutomation/Functions/ConvertFrom-BMOtterScriptExpression.ps1
@@ -42,6 +42,7 @@ function ConvertFrom-BMOtterScriptExpression
     param(
         # The OtterScript expression to convert to a PowerShell object.
         [Parameter(Mandatory, ValueFromPipeline)]
+        [AllowEmptyString()]
         [String] $Value
     )
 

--- a/BuildMasterAutomation/Functions/ConvertFrom-BMOtterScriptExpression.ps1
+++ b/BuildMasterAutomation/Functions/ConvertFrom-BMOtterScriptExpression.ps1
@@ -174,7 +174,7 @@ function ConvertFrom-BMOtterScriptExpression
 
         if ($isVector)
         {
-            return ,@($parsedItems | Where-Object { $_ } | ConvertFrom-BMOtterScriptExpression)
+            return ,@($parsedItems | ConvertFrom-BMOtterScriptExpression)
         }
 
         $hashtable = @{}

--- a/BuildMasterAutomation/Functions/ConvertFrom-BMOtterScriptExpression.ps1
+++ b/BuildMasterAutomation/Functions/ConvertFrom-BMOtterScriptExpression.ps1
@@ -174,7 +174,7 @@ function ConvertFrom-BMOtterScriptExpression
 
         if ($isVector)
         {
-            return ,@($parsedItems | ConvertFrom-BMOtterScriptExpression)
+            return ,@($parsedItems | Where-Object { $_ } | ConvertFrom-BMOtterScriptExpression)
         }
 
         $hashtable = @{}

--- a/BuildMasterAutomation/Functions/ConvertTo-BMOtterScriptExpression.ps1
+++ b/BuildMasterAutomation/Functions/ConvertTo-BMOtterScriptExpression.ps1
@@ -59,11 +59,17 @@ function ConvertTo-BMOtterScriptExpression
             $sortedKeys = $Value.Keys | Sort-Object
             foreach ($key in $sortedKeys)
             {
-                if ($Value[$key] -is [System.Collections.ICollection])
+                $keyValue = $Value[$key]
+                if ($keyValue -is [System.Collections.ICollection])
                 {
-                    $Value[$key] = ConvertTo-BMOtterScriptExpression -Value $Value[$key]
+                    $keyValue = ConvertTo-BMOtterScriptExpression -Value $keyValue
                 }
-                $mapExpression += "${key}: $($Value[$key]), "
+
+                if ($keyValue -eq '')
+                {
+                    $keyValue = '""'
+                }
+                $mapExpression += "${key}: $($keyValue), "
             }
 
             $mapExpression = $mapExpression -replace ', $'
@@ -79,6 +85,11 @@ function ConvertTo-BMOtterScriptExpression
                     $item = ConvertTo-BMOtterScriptExpression -Value $item
                     $item | Write-Output
                     continue
+                }
+
+                if ($item -eq '')
+                {
+                    $item = '""'
                 }
 
                 $item | Write-Output

--- a/BuildMasterAutomation/Functions/Get-BMVariable.ps1
+++ b/BuildMasterAutomation/Functions/Get-BMVariable.ps1
@@ -7,7 +7,7 @@ function Get-BMVariable
 
     .DESCRIPTION
     The `Get-BMVariable` function gets BuildMaster variables. By default, it gets all global variables. It can also get
-    all variables for a specific environment, server, server role, application group, and application variables.
+    all variables for a specific environment, server, server role, application group, application, release, and build.
 
     To get a specific variable, pass the variable's id, name, or object `Variable` parameter. If the variable doesn't
     exist, the function writes an error. To search for a variable, pass a wildcard string to the `Variable` parameter.
@@ -22,7 +22,15 @@ function Get-BMVariable
 
     To get an application's variables, pass the application's name to the `Application` parameter.
 
-    To get an OtterScript vector or map as a string, use the `Raw` switch.
+    To get a release's variables, pass the release object to the `Release` parameter. Use the `Get-BMRelease` function
+    to get a release object.
+
+    To get a build's variables, pass the build object to the `Build` parameter. Use the `Get-BMBuild` function to get a
+    build object.
+
+    This function returns the variable value as a PowerShell data structure. If the variable is an OtterScript vector,
+    it converts it to a PowerShell array; if it is an OtterScript map, it converts it to a PowerShell hashtable. To
+    return the variable value in its original OtterScript form as a PowerShell string, use the `Raw` switch.
 
     This function uses BuildMaster's [Variables Management](https://docs.inedo.com/docs/buildmaster-reference-api-variables)
     API. Due to a bug in BuildMaster, when getting application or application group variables, it uses BuildMaster's
@@ -89,9 +97,19 @@ function Get-BMVariable
     Demonstrates how to get a specific variable from an application.
 
     .EXAMPLE
+    Get-BMVariable -Session $session -Release (Get-BMRelease -Session $session -Release 'gitflow' -Application 'WebApp')
+
+    Demonstrates how to get all the variables for the "gitflow" release on the "WebApp" application.
+
+    .EXAMPLE
+    Get-BMVariable -Session $session -Build (Get-BMBuild -Session $session -Build 123)
+
+    Demonstrates how to get all the variables for build id 123.
+
+    .EXAMPLE
     Get-BMVariable -Session $session -Name 'Var' -Application 'www' -Raw
 
-    Demonstrates how to get a specific variable from an application as a string.
+    Demonstrates how to get a specific variable from an application as a string in its OtterScript expression form.
     #>
     [CmdletBinding(DefaultParameterSetName='global')]
     param(
@@ -128,6 +146,14 @@ function Get-BMVariable
         [Parameter(Mandatory, ParameterSetName='role')]
         [Alias('ServerRoleName')]
         [Object] $ServerRole,
+
+        # Specific release of the variable. Must be a Release object returned from the `Get-BMRelease` function.
+        [Parameter(Mandatory, ParameterSetName='releases')]
+        [Object] $Release,
+
+        # Specific build of the variable. Must be a Build object returned from the `Get-BMBuild` function.
+        [Parameter(Mandatory, ParameterSetName='builds')]
+        [Object] $Build,
 
         # Return the variable's value, not an object representing the variable.
         [switch] $ValueOnly,

--- a/BuildMasterAutomation/Functions/Invoke-BMRestMethod.ps1
+++ b/BuildMasterAutomation/Functions/Invoke-BMRestMethod.ps1
@@ -43,6 +43,7 @@ function Invoke-BMRestMethod
 
         # The body to send.
         [Parameter(Mandatory, ParameterSetName='CustomBody')]
+        [AllowEmptyString()]
         [String] $Body,
 
         # The content type of the web request.

--- a/BuildMasterAutomation/Functions/Invoke-BMVariableEndpoint.ps1
+++ b/BuildMasterAutomation/Functions/Invoke-BMVariableEndpoint.ps1
@@ -191,7 +191,7 @@ function Invoke-BMVariableEndpoint
         return
     }
 
-    if ($variables -is [String])
+    if ($variables.GetType().Name -ne 'PSCustomObject')
     {
         return [pscustomobject]@{
             Name = $variableName;

--- a/BuildMasterAutomation/Functions/Remove-BMVariable.ps1
+++ b/BuildMasterAutomation/Functions/Remove-BMVariable.ps1
@@ -7,7 +7,8 @@ function Remove-BMVariable
 
     .DESCRIPTION
     The `Remove-BMVariable` function deletes BuildMaster variables. By default, it deletes global variables. It can also
-    delete variables for a specific environment, server, server role, application group, and application variables.
+    delete variables for a specific environment, server, server role, application group, application, release, and
+    build.
 
     Pass the name of the variable to delete to the `Name` parameter. If no variable exists to delete, you'll get an
     error.
@@ -21,6 +22,12 @@ function Remove-BMVariable
     To delete an application group's variables, pass the application group's name to the `ApplicationGroupName` parameter.
 
     To delete an application's variables, pass the application's name to the `ApplicationName` parameter.
+
+    To delete a release's variables, pass the release object to the `Release` parameter. Use the `Get-BMRelease`
+    function to get a release object.
+
+    To delete a build's variables, pass the build object to the `Build` parameter. Use the `Get-BMBuild` function to get
+    a build object.
 
     Pass a session object representing the instance of BuildMaster to use to the `Session` parameter. Use
     `New-BMSession` to create a session object.
@@ -56,6 +63,16 @@ function Remove-BMVariable
     Demonstrates how to delete a variable from an application group.
 
     .EXAMPLE
+    Remove-BMVariable -Session $session -Name 'Var' -Release (Get-BMRelease -Session $session -Release 'gitflow' -Application 'WebApp')
+
+    Demonstrates how to delete a variable from a release.
+
+    .EXAMPLE
+    Remove-BMVariable -Session $session -Name 'Var' -Build (Get-BMBuild -Session $session -Build 123)
+
+    Demonstrates how to delete a variable from a build.
+
+    .EXAMPLE
     Remove-BMVariable -Session $session -Name 'Var' -ApplicationName 'www'
 
     Demonstrates how to delete a variable from an application.
@@ -89,7 +106,15 @@ function Remove-BMVariable
 
         # The server role of the variable to delete. Pass a server role id, name, or object.
         [Parameter(Mandatory, ParameterSetName='role')]
-        [Object] $ServerRole
+        [Object] $ServerRole,
+
+        # Specific release of the variable to delete. Must be a Release object returned from the `Get-BMRelease` function.
+        [Parameter(Mandatory, ParameterSetName='releases')]
+        [Object] $Release,
+
+        # Specific build of the variable to delete. Must be a Build object returned from the `Get-BMBuild` function.
+        [Parameter(Mandatory, ParameterSetName='builds')]
+        [Object] $Build
     )
 
     process
@@ -103,5 +128,4 @@ function Remove-BMVariable
                                   -BoundParameter $PSBoundParameters `
                                   -ForDelete
     }
-
 }

--- a/BuildMasterAutomation/Functions/Set-BMVariable.ps1
+++ b/BuildMasterAutomation/Functions/Set-BMVariable.ps1
@@ -131,17 +131,23 @@ function Set-BMVariable
 
         # Specific build where the variable will be created. Must be a Build object returned from the `Get-BMBuild` function.
         [Parameter(Mandatory, ParameterSetName='builds')]
-        [Object] $Build
+        [Object] $Build,
+
+        # Pass the value as-is to BuildMaster, do not attempt to convert to OtterScript expression.
+        [switch] $Raw
     )
 
     Set-StrictMode -Version 'Latest'
     Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
 
-    $Value = ConvertTo-BMOtterScriptExpression -Value $Value
-
-    if ($Value -eq $null)
+    if (-not $Raw)
     {
-        return
+        $Value = ConvertTo-BMOtterScriptExpression -Value $Value
+
+        if ($Value -eq $null)
+        {
+            return
+        }
     }
 
     Invoke-BMVariableEndpoint -Session $Session `

--- a/BuildMasterAutomation/Functions/Set-BMVariable.ps1
+++ b/BuildMasterAutomation/Functions/Set-BMVariable.ps1
@@ -7,13 +7,16 @@ function Set-BMVariable
 
     .DESCRIPTION
     The `Set-BMVariable` function creates or sets the value of a BuildMaster variable. By default, it creates/sets
-    global variables. It can also set environment, server, server role, application group, and application variables.
+    global variables. It can also set variables for a specific environment, server, server role, application group,
+    application, release, and build.
 
-    Pass the variable's name to the `Name` parameter. Pass the variable's value to the `Value` parameter. If the raw
-    flag is used then the variable is passed as-is to buildmaster, otherwise it will be converted to an OtterScript
-    value. If the variable is a PowerShell hashtable then it will be converted to an OtterScript map. If the
-    variable is a PowerShell array then it will be converted to an OtterScript vector. All other types will be left as
-    their default string representation.
+    Pass the variable's name to the `Name` parameter and pass the variable's value to the `Value` parameter.
+
+    The function takes variable values as PowerShell data structures and converts them to OtterScript expressions before
+    they're passed to BuildMaster. A PowerShell hashtable is converted to an OtterScript map, a PowerShell array is
+    converted to an OtterScript vector, and any other types are passed as their default string representation.
+
+    Use the `Raw` switch to pass the variable value as-is to BuildMaster, i.e. no type conversion.
 
     To set an environment's variable, pass the environment's name to the `EnvironmentName` parameter.
 
@@ -24,6 +27,12 @@ function Set-BMVariable
     To set an application group's variable, pass the application group's name to the `ApplicationGroupName` parameter.
 
     To set an application's variable, pass the application's name to the `ApplicationName` parameter.
+
+    To set a release's variable, pass the release object to the `Release` parameter. Use the `Get-BMRelease` function to
+    get a release object.
+
+    To set a build's variable, pass the build object to the `Build` parameter. Use the `Get-BMBuild` function to get a
+    build object.
 
     Pass a session object representing the instance of BuildMaster to use to the `Session` parameter. Use
     `New-BMSession` to create a session object.
@@ -59,6 +68,16 @@ function Set-BMVariable
     Set-BMVariable -Session $session -Name 'Var' -Value 'Value' -ApplicationName 'www'
 
     Demonstrates how to create or set a variable for an application.
+
+    .EXAMPLE
+    Set-BMVariable -Session $session -Name 'Var' -Value 'Value' -Release (Get-BMRelease -Session $session -Release 'gitflow' -Application 'WebApp')
+
+    Demonstrates how to set a variable for a release.
+
+    .EXAMPLE
+    Set-BMVariable -Session $session -Name 'Var' -Value 'Value' -Build (Get-BMBuild -Session $session -Build 123)
+
+    Demonstrates how to set a variable for a build.
 
     .EXAMPLE
     Set-BMVariable -Session $session -Name 'var' -Value @('hi', 'there') -ApplicationName 'www'
@@ -104,7 +123,15 @@ function Set-BMVariable
         # The name of the server role where the variable should be created. The default is to create a global variable.
         [Parameter(Mandatory,ParameterSetName='role')]
         [Alias('ServerRoleName')]
-        [Object] $ServerRole
+        [Object] $ServerRole,
+
+        # Specific release where the variable will be created. Must be a Release object returned from the `Get-BMRelease` function.
+        [Parameter(Mandatory, ParameterSetName='releases')]
+        [Object] $Release,
+
+        # Specific build where the variable will be created. Must be a Build object returned from the `Get-BMBuild` function.
+        [Parameter(Mandatory, ParameterSetName='builds')]
+        [Object] $Build
     )
 
     Set-StrictMode -Version 'Latest'

--- a/BuildMasterAutomation/Functions/Set-BMVariable.ps1
+++ b/BuildMasterAutomation/Functions/Set-BMVariable.ps1
@@ -143,11 +143,6 @@ function Set-BMVariable
     if (-not $Raw)
     {
         $Value = ConvertTo-BMOtterScriptExpression -Value $Value
-
-        if ($Value -eq $null)
-        {
-            return
-        }
     }
 
     Invoke-BMVariableEndpoint -Session $Session `

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,23 +16,13 @@
 
 ### Fixed
 
+* Some files contained character sequences that cause anti-virus software, Cortex XDR, to crash PowerShell.
 * `Get-BMVariable` doesn't return anything when using `-ValueOnly` and that value is an integer.
 * `Get-BMVariable` fails to find variables the variable's value is an empty string.
 * `Get-BMVariable` fails to get vector variables that contain empty items.
 * `Set-BMVariable`'s `-Raw` parameter was documented but never implemented.
 * `Set-BMVariables` fails to set a variable to an empty string value.
 * `Remove-BMVariable` fails to remove a variable with an empty string value.
-
-## 4.0.1
-
-### Fixed
-
-Some files contained character sequences that cause anti-virus software, Cortex XDR, to crash PowerShell.
-
-### Changed
-
-* Tested against BuildMaster 2023.14.
-
 
 ## 4.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 * Some files contained character sequences that cause anti-virus software, Cortex XDR, to crash PowerShell.
 * `Get-BMVariable` doesn't return anything when using `-ValueOnly` and that value is an integer.
-* `Get-BMVariable` fails to find variables the variable's value is an empty string.
+* `Get-BMVariable` fails to find variables if the variable's value is an empty string.
 * `Get-BMVariable` fails to get vector variables that contain empty items.
 * `Set-BMVariable`'s `-Raw` parameter was documented but never implemented.
 * `Set-BMVariables` fails to set a variable to an empty string value.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ## 4.1.0
 
+> Released 28 May 2024
+
 ### Added
 
 * Added support for `Release` and `Build` variables to the `Get-BMVariable`, `Set-BMVariable`, and `Remove-BMVariale`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 
 # BuildMasterAutomation Changelog
 
+## 4.1.0
+
+### Added
+
+* Added support for `Release` and `Build` variables to the `Get-BMVariable`, `Set-BMVariable`, and `Remove-BMVariale`
+  functions.
+
+### Changed
+
+* Tested against BuildMaster 2023.15.
+
+### Fixed
+
+* `Get-BMVariable` doesn't return anything when using `-ValueOnly` and that value is an integer.
+* `Get-BMVariable` fails to find variables the variable's value is an empty string.
+* `Get-BMVariable` fails to get vector variables that contain empty items.
+* `Set-BMVariable`'s `-Raw` parameter was documented but never implemented.
+* `Set-BMVariables` fails to set a variable to an empty string value.
+* `Remove-BMVariable` fails to remove a variable with an empty string value.
+
 ## 4.0.1
 
 ### Fixed

--- a/Tests/BuildMasterAutomationTest/BuildMasterAutomationTest.psm1
+++ b/Tests/BuildMasterAutomationTest/BuildMasterAutomationTest.psm1
@@ -70,26 +70,6 @@ finally
     $conn.Close()
 }
 
-function New-BMTestApplication
-{
-    [CmdletBinding(DefaultParameterSetName='ByCommandPath')]
-    param(
-        [Object] $Session,
-
-        [Parameter(Mandatory, ParameterSetName='ByCommandPath')]
-        [String]$CommandPath,
-
-        [Parameter(Mandatory, ParameterSetName='ByName')]
-        [String] $Name
-    )
-
-    if (-not $Name)
-    {
-        $Name = New-BMTestObjectName
-    }
-
-    return New-BMApplication -Session $Session -Name $Name
-}
 
 $script:session = New-BMSession -Url $url -ApiKey $apiKey
 $script:objectNum = 0

--- a/Tests/ConvertFrom-BMOtterScriptExpression.Tests.ps1
+++ b/Tests/ConvertFrom-BMOtterScriptExpression.Tests.ps1
@@ -165,4 +165,22 @@ Describe 'ConvertFrom-BMOtterScriptExpression' {
         WhenConverting
         ThenEqual ''
     }
+
+    It 'should remove empty items from vectors' {
+        GivenValue '@(one, )'
+        WhenConverting
+        ThenEqual @('one')
+
+        GivenValue '@(, two)'
+        WhenConverting
+        ThenEqual @('two')
+
+        GivenValue '@(, three, )'
+        WhenConverting
+        ThenEqual @('three')
+
+        GivenValue '@(, , , , , )'
+        WhenConverting
+        ThenEqual @()
+    }
 }

--- a/Tests/ConvertFrom-BMOtterScriptExpression.Tests.ps1
+++ b/Tests/ConvertFrom-BMOtterScriptExpression.Tests.ps1
@@ -27,7 +27,7 @@ BeforeAll {
             $Result
         )
 
-        if (-not $Result)
+        if (-not $PSBoundParameters.Keys.Contains('Result'))
         {
             $Result = $script:result
         }
@@ -166,21 +166,21 @@ Describe 'ConvertFrom-BMOtterScriptExpression' {
         ThenEqual ''
     }
 
-    It 'should remove empty items from vectors' {
+    It 'should not remove empty items from vectors' {
         GivenValue '@(one, )'
         WhenConverting
-        ThenEqual @('one')
+        ThenEqual @('one', '')
 
         GivenValue '@(, two)'
         WhenConverting
-        ThenEqual @('two')
+        ThenEqual @('', 'two')
 
         GivenValue '@(, three, )'
         WhenConverting
-        ThenEqual @('three')
+        ThenEqual @('', 'three', '')
 
         GivenValue '@(, , , , , )'
         WhenConverting
-        ThenEqual @()
+        ThenEqual @('', '', '', '', '', '')
     }
 }

--- a/Tests/ConvertFrom-BMOtterScriptExpression.Tests.ps1
+++ b/Tests/ConvertFrom-BMOtterScriptExpression.Tests.ps1
@@ -156,8 +156,13 @@ Describe 'ConvertFrom-BMOtterScriptExpression' {
         GivenValue '@(@(), @())'
         WhenConverting
         ThenEqual @(@(), @())
+
         GivenValue '@(%(), %())'
         WhenConverting
         ThenEqual @(@{}, @{})
+
+        GivenValue ''
+        WhenConverting
+        ThenEqual ''
     }
 }

--- a/Tests/ConvertTo-BMOtterScriptExpression.Tests.ps1
+++ b/Tests/ConvertTo-BMOtterScriptExpression.Tests.ps1
@@ -16,8 +16,11 @@ BeforeAll {
 
     function WhenConverting
     {
+        [CmdletBinding()]
+        param()
+
         $warnings = @()
-        $script:result = ConvertTo-BMOtterScriptExpression -Value $script:value -WarningVariable 'warnings' -ErrorAction SilentlyContinue
+        $script:result = ConvertTo-BMOtterScriptExpression -Value $script:value -WarningVariable 'warnings'
         $script:warnings = $warnings
     }
 
@@ -108,11 +111,29 @@ Describe 'ConvertTo-BMOtterScriptExpression' {
         ThenEquals '@(1, 2, 3, @(4, 5, 6))'
     }
 
-    It 'should throw error' {
-        $value = [System.Collections.DictionaryEntry]::new('hi', 'there')
-        GivenValue $value
+    It 'should support empty strings' {
+        GivenValue ''
         WhenConverting
+        ThenEquals ''
+    }
+
+    It 'should support empty arrays' {
+        GivenValue @()
+        WhenConverting
+        ThenIsVector
+        ThenEquals '@()'
+    }
+
+    It 'should support empty hashtables' {
+        GivenValue @{}
+        WhenConverting
+        ThenIsMap
+        ThenEquals '%()'
+    }
+
+    It 'should throw error' {
+        GivenValue ([System.Exception]::new())
+        { WhenConverting -ErrorAction Stop } | Should -Throw 'Unable to convert *'
         $script:result | Should -Be $null
-        ThenError -MatchesPattern 'Unable to convert*'
     }
 }

--- a/Tests/ConvertTo-BMOtterScriptExpression.Tests.ps1
+++ b/Tests/ConvertTo-BMOtterScriptExpression.Tests.ps1
@@ -124,11 +124,40 @@ Describe 'ConvertTo-BMOtterScriptExpression' {
         ThenEquals '@()'
     }
 
+    It 'should support arrays with empty string items' {
+        GivenValue @('first', '', '')
+        WhenConverting
+        ThenIsVector
+        ThenEquals '@(first, "", "")'
+
+        GivenValue @('', 'middle', '')
+        WhenConverting
+        ThenIsVector
+        ThenEquals '@("", middle, "")'
+
+        GivenValue @('', '', 'last')
+        WhenConverting
+        ThenIsVector
+        ThenEquals '@("", "", last)'
+
+        GivenValue @('', '', '', '')
+        WhenConverting
+        ThenIsVector
+        ThenEquals '@("", "", "", "")'
+    }
+
     It 'should support empty hashtables' {
         GivenValue @{}
         WhenConverting
         ThenIsMap
         ThenEquals '%()'
+    }
+
+    It 'should support hashtables with empty string values' {
+        GivenValue @{ 1 = ''; 2 = 'two'; 3 = ''}
+        WhenConverting
+        ThenIsMap
+        ThenEquals '%(1: "", 2: two, 3: "")'
     }
 
     It 'should throw error' {

--- a/Tests/Get-BMVariable.Tests.ps1
+++ b/Tests/Get-BMVariable.Tests.ps1
@@ -70,6 +70,7 @@ BeforeAll {
             [string] $Named,
 
             [Parameter(Mandatory)]
+            [AllowEmptyString()]
             [string] $WithValue,
 
             [string] $ForApplication,
@@ -153,12 +154,12 @@ BeforeAll {
     {
         param(
             [Parameter(Mandatory)]
-            [string[]]$Value
+            [AllowEmptyString()]
+            [string[]]$ExpectedValue
         )
 
-        $script:result | Should -Not -BeNullOrEmpty
-        $script:result | Should -HaveCount $Value.Count
-        $script:result | Should -Be $Value
+        $script:result | Should -HaveCount $ExpectedValue.Count
+        $script:result | Should -Be $ExpectedValue
     }
 
     function WhenGettingVariable
@@ -345,6 +346,12 @@ Describe 'Get-BMVariable' {
         ThenVariableValuesReturned 'Fubar'
     }
 
+    It 'should return an empty string when variable is empty' {
+        GivenVariable 'EmptyVar' -WithValue ''
+        WhenGettingVariable 'EmptyVar' -ValueOnly
+        ThenVariableValuesReturned ''
+    }
+
     It 'should return the variables for an application' {
         $app = GivenApplication
         GivenVariable 'GlobalVar' -WithValue 'GlobalSnafu'
@@ -364,7 +371,6 @@ Describe 'Get-BMVariable' {
         ThenNoErrorWritten
     }
 
-    # Doesn't currently work in BuildMaster.
     It 'should return application group''s variable' {
         GivenApplicationGroup 'fizzbuzz'
         GivenVariable 'GlobalVar' -WithValue 'GlobalSnafu'

--- a/Tests/Get-BMVariable.Tests.ps1
+++ b/Tests/Get-BMVariable.Tests.ps1
@@ -12,7 +12,7 @@ BeforeAll {
 
     function GivenApplication
     {
-        New-BMTestApplication -Session $script:session -CommandPath $PSCommandPath | Write-Output
+        GivenAnApplication -Name $PSCommandPath
     }
 
     function GivenApplicationGroup

--- a/Tests/Remove-BMVariable.Tests.ps1
+++ b/Tests/Remove-BMVariable.Tests.ps1
@@ -82,6 +82,7 @@ BeforeAll {
             [string] $Named,
 
             [Parameter(Mandatory)]
+            [AllowEmptyString()]
             [string] $WithValue,
 
             [string] $ForApplication,
@@ -294,6 +295,32 @@ Describe 'Remove-BMVariable' {
         ThenNoErrorWritten
     }
 
+    It 'should remove global variable when it is empty' {
+        GivenVariable 'EmptyGlobalVar' -WithValue ''
+        WhenRemovingVariable 'EmptyGlobalVar'
+        ThenVariableRemoved 'EmptyGlobalVar'
+        ThenNoErrorWritten
+    }
+
+    It 'should remove application variable when it is empty' {
+        $app = GivenApplication
+        GivenVariable -Named 'EmptyAppVar' -WithValue '' -ForApplication $app.Application_Name
+        WhenRemovingVariable 'EmptyAppVar' -ForApplication $app.Application_Name
+        ThenVariableRemoved 'EmptyAppVar' -ForApplication $app.Application_Name
+        ThenNoErrorWritten
+    }
+
+    It 'should remove build variable when it is empty' {
+        $application = GivenAnApplication -Name 'Remove-BMVariable'
+        $pipeline = GivenAPipeline -Named 'Remove-BMVariable' -ForApplication $application
+        $release = GivenARelease -Named 'Remove-BMVariable' -ForApplication $application -WithNumber '1.0' -UsingPipeline $pipeline
+        $build = GivenABuild -ForRelease $release
+        GivenVariable 'EmptyBuildVar' -WithValue '' -ForBuild $build
+        WhenRemovingVariable 'EmptyBuildVar' -ForBuild $build
+        ThenVariableRemoved 'EmptyBuildVar' -ForBuild $build
+        ThenNoErrorWritten
+    }
+
     It 'should ignore variable that does not exist' {
         WhenRemovingVariable 'GlobalVar' -ErrorAction Ignore
         ThenNoErrorWritten
@@ -324,7 +351,6 @@ Describe 'Remove-BMVariable' {
                           -ParameterFilter { $Name -eq $expectedName }
     }
 
-    # BuildMaster's API doesn't work with application variables.
     It 'should remove application variable' {
         $app = GivenApplication
         GivenVariable -Named 'AppFubar' -WithValue 'AppValue' -ForApplication $app.Application_Name
@@ -343,7 +369,6 @@ Describe 'Remove-BMVariable' {
         ThenNoErrorWritten
     }
 
-    # BuildMaster's API doesn't work with application group variables.
     It 'should remove application group variable' {
         GivenApplicationGroup 'fizzbuzz'
         GivenVariable -Named 'AppGroupFubar' -WithValue 'AppGropuValue' -ForApplicationGroup 'fizzbuzz'

--- a/Tests/Remove-BMVariable.Tests.ps1
+++ b/Tests/Remove-BMVariable.Tests.ps1
@@ -12,21 +12,7 @@ BeforeAll {
 
     function GivenApplication
     {
-        param(
-            [String] $Named
-        )
-
-        $optionalArgs = @{}
-        if ($Named)
-        {
-            $optionalArgs['Name'] = $Named
-        }
-        else
-        {
-            $optionalArgs['CommandPath'] = $PSCommandPath
-        }
-
-        New-BMTestApplication -Session $script:session @optionalArgs
+        GivenAnApplication -Name $PSCommandPath
     }
 
     function GivenApplicationGroup

--- a/Tests/Set-BMVariable.Tests.ps1
+++ b/Tests/Set-BMVariable.Tests.ps1
@@ -12,7 +12,7 @@ BeforeAll {
 
     function GivenApplication
     {
-        New-BMTestApplication -Session $script:session -CommandPath $PSCommandPath
+        GivenAnApplication -Name $PSCommandPath
     }
 
     function GivenApplicationGroup

--- a/Tests/Set-BMVariable.Tests.ps1
+++ b/Tests/Set-BMVariable.Tests.ps1
@@ -136,6 +136,10 @@ BeforeAll {
 
             [string] $ForServerRole,
 
+            [Object] $ForRelease,
+
+            [Object] $ForBuild,
+
             [switch] $Raw
         )
 
@@ -166,6 +170,16 @@ BeforeAll {
             $optionalParams['ServerRole'] = $ForServerRole
         }
 
+        if ($ForRelease)
+        {
+            $optionalParams['Release'] = $ForRelease
+        }
+
+        if ($ForBuild)
+        {
+            $optionalParams['Build'] = $ForBuild
+        }
+
         if ($Raw)
         {
             $optionalParams['Raw'] = $true
@@ -189,6 +203,8 @@ BeforeAll {
             [String] $ForEnvironment,
             [String] $ForServer,
             [String] $ForServerRole,
+            [Object] $ForRelease,
+            [Object] $ForBuild,
             [Switch] $WhatIf
         )
 
@@ -217,6 +233,16 @@ BeforeAll {
         if ($ForServerRole)
         {
             $optionalParams['ServerRole'] = $ForServerRole
+        }
+
+        if ($ForRelease)
+        {
+            $optionalParams['Release'] = $ForRelease
+        }
+
+        if ($ForBuild)
+        {
+            $optionalParams['Build'] = $ForBuild
         }
 
         if ($WhatIf)
@@ -296,6 +322,25 @@ Describe 'Set-BMVariable' {
         GivenServerRole 'SetBMVariable'
         WhenSettingVariable 'ServerRoleVar' -WithValue 'ServerRoleValue' -ForServerRole 'SetBMVariable'
         ThenVariableSet 'ServerRoleVar' -To 'ServerRoleValue' -ForServerRole 'SetBMVariable'
+        ThenNoErrorWritten
+    }
+
+    It 'should create release variable' {
+        $application = GivenAnApplication -Name 'Set-BMVariable'
+        $pipeline = GivenAPipeline -Named 'Set-BMVariable' -ForApplication $application
+        $release = GivenARelease -Named 'Set-BMVariable' -ForApplication $application -WithNumber '1.0' -UsingPipeline $pipeline
+        WhenSettingVariable 'ReleaseVar' -WithValue 'ReleaseVarValue' -ForRelease $release
+        ThenVariableSet 'ReleaseVar' -To 'ReleaseVarValue' -ForRelease $release
+        ThenNoErrorWritten
+    }
+
+    It 'should create build variable' {
+        $application = GivenAnApplication -Name 'Set-BMVariable'
+        $pipeline = GivenAPipeline -Named 'Set-BMVariable' -ForApplication $application
+        $release = GivenARelease -Named 'Set-BMVariable' -ForApplication $application -WithNumber '1.0' -UsingPipeline $pipeline
+        $build = GivenABuild -ForRelease $release
+        WhenSettingVariable 'BuildVar' -WithValue 'BuildVarValue' -ForBuild $build
+        ThenVariableSet 'BuildVar' -To 'BuildVarValue' -ForBuild $build
         ThenNoErrorWritten
     }
 

--- a/Tests/Stop-BMRelease.Tests.ps1
+++ b/Tests/Stop-BMRelease.Tests.ps1
@@ -8,7 +8,7 @@ BeforeAll {
     & (Join-Path -Path $PSScriptRoot -ChildPath 'Initialize-Tests.ps1' -Resolve)
 
     $script:session = New-BMTestSession
-    $script:app = New-BMTestApplication -Session $session -CommandPath $PSCommandPath
+    $script:app = GivenAnApplication -Name $PSCommandPath
     $script:pipeline = GivenAPipeline $app.Application_Name -ForApplication $app
 
     function GivenARelease

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,42 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure('2') do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  config.vm.define 'buildmaster' do |buildmaster|
+    # https://app.vagrantup.com/gusztavvargadr/boxes/sql-server
+    buildmaster.vm.box = 'gusztavvargadr/sql-server'
+
+    buildmaster.vm.network 'forwarded_port', guest: 8622, host: 8622
+
+    buildmaster.vm.provider 'virtualbox' do |vb|
+      vb.gui = true
+      vb.memory = '4096'
+    end
+
+    buildmaster.vm.provider 'hyperv' do |hv|
+      hv.memory = '4096'
+    end
+
+    buildmaster.vm.provision 'shell', inline: <<-'SHELL'
+      $ErrorActionPreference = 'Stop'
+
+      # InedoHub installs BuildMaster to run as the Network Service built-in.
+      sqlcmd.exe -Q 'CREATE LOGIN [NT AUTHORITY\NETWORK SERVICE] FROM WINDOWS;'
+
+      New-NetFirewallRule -DisplayName 'Allow BuildMaster Web Server' -Direction Inbound -Protocol TCP -LocalPort 8622 | Write-Verbose
+
+      $inedoHubRoot = 'C:\Users\vagrant\Downloads\InedoHub'
+      $inedoHubZip = "$($inedoHubRoot).zip"
+      Invoke-WebRequest -Uri 'https://proget.inedo.com/upack/Products/download/InedoReleases/DesktopHub?contentOnly=zip&latest' -OutFile $inedoHubZip
+      Expand-Archive -Path $inedoHubZip -DestinationPath $inedoHubRoot
+
+      Install-Module -Name 'PackageManagement' -Scope CurrentUser -MinimumVersion '1.3.2' -MaximumVersion '1.4.8.1' -Repository 'PSGallery' -AllowClobber -Force
+      Install-Module -Name 'PowerShellGet' -Scope CurrentUser -MinimumVersion '2.0.0' -MaximumVersion '2.2.5' -Repository 'PSGallery' -AllowClobber -Force
+      Install-Module -Name 'Prism' -Scope CurrentUser -Repository 'PSGallery' -Force
+      SHELL
+  end
+end

--- a/init.ps1
+++ b/init.ps1
@@ -30,7 +30,7 @@ Import-Module -Name 'Microsoft.PowerShell.Archive' -Verbose:$false
 
 # When updating the version, it's a good time to check if bugs in the API have been fixed. Search all the tests for
 # "-Skip", remove the "-Skip" flag and run tests.
-$version = '23.0.14'
+$version = '23.0.15'
 
 Write-Information -Message "Testing BuildMaster ${version}."
 

--- a/init.ps1
+++ b/init.ps1
@@ -25,13 +25,8 @@ Set-StrictMode -Version 'Latest'
 $ErrorActionPreference = 'Stop'
 $InformationPreference = 'Continue'
 
-& {
-    $VerbosePreference = 'SilentlyContinue'
-    Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath 'PSModules\Carbon.Windows.Installer') -Force
-    Import-Module -Name 'Microsoft.PowerShell.Archive'
-}
-
-
+Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath 'PSModules\Carbon.Windows.Installer') -Force -Verbose:$false
+Import-Module -Name 'Microsoft.PowerShell.Archive' -Verbose:$false
 
 # When updating the version, it's a good time to check if bugs in the API have been fixed. Search all the tests for
 # "-Skip", remove the "-Skip" flag and run tests.


### PR DESCRIPTION
### Added

* Added support for `Release` and `Build` variables to the `Get-BMVariable`, `Set-BMVariable`, and `Remove-BMVariale`
  functions.

### Changed

* Tested against BuildMaster 2023.15.

### Fixed

* Some files contained character sequences that cause anti-virus software, Cortex XDR, to crash PowerShell.
* `Get-BMVariable` doesn't return anything when using `-ValueOnly` and that value is an integer.
* `Get-BMVariable` fails to find variables if the variable's value is an empty string.
* `Get-BMVariable` fails to get vector variables that contain empty items.
* `Set-BMVariable`'s `-Raw` parameter was documented but never implemented.
* `Set-BMVariables` fails to set a variable to an empty string value.
* `Remove-BMVariable` fails to remove a variable with an empty string value.